### PR TITLE
Fixes operation name extraction when validation fails

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -111,14 +111,14 @@ function createPlugin(instrumentationApi) {
 }
 
 function getDetailsFromDocument(document) {
-  // TODO: when would there be multiple document definitions?
   const definition = document.definitions[0]
 
   const longestSelectionPath = getLongestSelectionPath(definition)
+  const definitionName = definition.name && definition.name.value
 
   return {
     operationType: definition.operation,
-    operationName: definition.name || '<anonymous>',
+    operationName: definitionName || '<anonymous>',
     longestPath: longestSelectionPath.join('.')
   }
 }

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -12,7 +12,8 @@
       },
       "files": [
         "transaction-naming.test.js",
-        "segments.test.js"
+        "segments.test.js",
+        "agent-disabled.test.js"
       ]
     }
   ],


### PR DESCRIPTION
For named queries, the operation name extraction was treating the object as a string and thus ending up with '[object Object]' instead of the proper name.

This adds the missing test case and resolves that. Also adds a file to the apollo-server versioned test runs that was missed earlier.

Fixes: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/33