### PR TITLE
Sets appropriate context on error capture for span/error relationship.

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -4,8 +4,11 @@
  */
 
 'use strict'
+
 const ErrorHelper = require('./error-helper.js')
-const errorHelper = new ErrorHelper
+const errorHelper = new ErrorHelper()
+
+const NOTICED_ERRORS = ErrorHelper.NOTICED_ERRORS
 
 function createPlugin(instrumentationApi) {
   if (!instrumentationApi) {
@@ -13,7 +16,7 @@ function createPlugin(instrumentationApi) {
   }
 
   return {
-    requestDidStart() {
+    requestDidStart(requestContext) {
       const requestParent = instrumentationApi.getActiveSegment()
 
       // We do not set to active here as batched queries will hit this
@@ -30,11 +33,16 @@ function createPlugin(instrumentationApi) {
       }
 
       return {
-        didEncounterErrors(requestContext) {
-          errorHelper.addErrorsFromApolloRequestContext(
-            instrumentationApi,
-            requestContext
-          )
+        didEncounterErrors(errorsRequestContext) {
+          // Since we don't set the operation segment as active, we want to apply the
+          // operation segment as active while setting the error to appropriately assign
+          // error attributes for any errors we've not noticed on field resolve.
+          instrumentationApi.applySegment(function addErrors() {
+            errorHelper.addErrorsFromApolloRequestContext(
+              instrumentationApi,
+              errorsRequestContext
+            )
+          }, operationSegment)
         },
         executionDidStart() {
           return {
@@ -62,7 +70,16 @@ function createPlugin(instrumentationApi) {
                 longestResolvedPath.formatted = formattedPath
               }
 
-              return () => {
+              return (error) => {
+                if (error) {
+                  // This handler is invoked prior to didEncounterErrors
+                  // which means we need to handle the error now to capture
+                  // in context of the appropriate span.
+                  errorHelper.noticeError(instrumentationApi, error)
+                  requestContext[NOTICED_ERRORS] = requestContext[NOTICED_ERRORS] || []
+                  requestContext[NOTICED_ERRORS].push(error)
+                }
+
                 resolverSegment.end()
                 instrumentationApi.setActiveSegment(currentSeg)
               }

--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -1,4 +1,7 @@
 'use strict'
+
+const NOTICED_ERRORS = Symbol('New Relic Noticed Errors')
+
 class ErrorHelper {
   isValidRequestContext(instrumentationApi, requestContext) {
     if (
@@ -19,12 +22,26 @@ class ErrorHelper {
     }
 
     for (const error of requestContext.errors) {
-      instrumentationApi.agent.errors.add(
-        instrumentationApi.tracer.getTransaction(),
-        error
-      )
+      if (!isErrorNoticed(error, requestContext)) {
+        this.noticeError(instrumentationApi, error)
+      }
     }
   }
+
+  noticeError(instrumentationApi, error) {
+    const transaction = instrumentationApi.tracer.getTransaction()
+    instrumentationApi.agent.errors.add(transaction, error)
+  }
 }
+
+function isErrorNoticed(error, requestContext) {
+  if (!error.originalError || !requestContext[NOTICED_ERRORS]) {
+    return false
+  }
+
+  return requestContext[NOTICED_ERRORS].indexOf(error.originalError) >= 0
+}
+
+ErrorHelper.NOTICED_ERRORS = NOTICED_ERRORS
 
 module.exports = ErrorHelper

--- a/tests/versioned/agent-testing.js
+++ b/tests/versioned/agent-testing.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+// TODO: ideally, we wouldn't be reachign into internals
+// and would have an API (in agent package?) to get what we need.
+// This sort of thing makes future refactors more difficult even
+// when extracted to a single location in the external module.
+
+function getErrorTraces(agent) {
+  const errorTraces = agent.errors.traceAggregator.errors
+  return errorTraces
+}
+
+function getSpanEvents(agent) {
+  const spans = agent.spanEventAggregator.getEvents()
+  return spans
+}
+
+function findSpanById(agent, spanId) {
+  const spans = getSpanEvents(agent)
+
+  const matchingSpan = spans.find((value) => {
+    const {intrinsics} = value
+    return intrinsics.guid === spanId
+  })
+
+  return matchingSpan
+}
+
+module.exports = {
+  getErrorTraces,
+  getSpanEvents,
+  findSpanById
+}

--- a/tests/versioned/apollo-server-express/errors.test.js
+++ b/tests/versioned/apollo-server-express/errors.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const utils = require('@newrelic/test-utilities')
+utils.assert.extendTap(tap)
+
+const { getTypeDefs, resolvers } = require('../data-definitions')
+const { createErrorTests } = require('../errors-tests')
+
+tap.test('apollo-server-express: errors', (t) => {
+  t.autoend()
+
+  let server = null
+  let expressServer = null
+  let serverUrl = null
+  let helper = null
+
+  t.beforeEach((done) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented({
+      distributed_tracing: { enabled: true } // enable span testing
+    })
+    const createPlugin = require('../../../lib/create-plugin')
+    const nrApi = helper.getAgentApi()
+
+    // TODO: eventually use proper function for instrumenting and not .shim
+    const plugin = createPlugin(nrApi.shim)
+
+    const express = require('express')
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const { ApolloServer, gql } = require('apollo-server-express')
+    server = new ApolloServer({
+      typeDefs: getTypeDefs(gql),
+      resolvers,
+      plugins: [plugin]
+    })
+
+    const app = express()
+    server.applyMiddleware({ app })
+
+    expressServer = app.listen(0, () => {
+      serverUrl = `http://localhost:${expressServer.address().port}${server.graphqlPath}`
+
+      t.context.helper = helper
+      t.context.serverUrl = serverUrl
+      done()
+    })
+  })
+
+  t.afterEach((done) => {
+    expressServer && expressServer.close()
+    server && server.stop()
+
+    helper.unload()
+    server = null
+    serverUrl = null
+    helper = null
+
+    clearCachedModules(['express', 'apollo-server-express'], () => {
+      done()
+    })
+  })
+
+  createErrorTests(t)
+})
+
+function clearCachedModules(modules, callback) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+
+  callback()
+}

--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -13,7 +13,8 @@
       },
       "files": [
         "transaction-naming.test.js",
-        "segments.test.js"
+        "segments.test.js",
+        "errors.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-hapi/errors.test.js
+++ b/tests/versioned/apollo-server-hapi/errors.test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const utils = require('@newrelic/test-utilities')
+const { getTypeDefs, resolvers } = require('../data-definitions')
+const { createErrorTests } = require('../errors-tests')
+
+tap.test('apollo-server-hapi: errors', (t) => {
+  t.autoend()
+
+  let server = null
+  let hapiServer = null
+  let serverUrl = null
+  let helper = null
+
+  t.beforeEach(async () => {
+    // load default instrumentation. hapi being critical
+    helper = utils.TestAgent.makeInstrumented({
+      distributed_tracing: { enabled: true } // enable span testing
+    })
+    const createPlugin = require('../../../lib/create-plugin')
+    const nrApi = helper.getAgentApi()
+
+    // TODO: eventually use proper function for instrumenting and not .shim
+    const plugin = createPlugin(nrApi.shim)
+
+    const Hapi = require('@hapi/hapi')
+
+    const graphqlPath = '/gql'
+
+    // Do after instrumentation to ensure hapi isn't loaded too soon.
+    const { ApolloServer, gql } = require('apollo-server-hapi')
+    server = new ApolloServer({
+      typeDefs: getTypeDefs(gql),
+      resolvers,
+      plugins: [plugin]
+    })
+
+    hapiServer = Hapi.server({
+      host: 'localhost',
+      port: 5000
+    })
+
+    await server.applyMiddleware({ app: hapiServer, path: graphqlPath })
+
+    await server.installSubscriptionHandlers(hapiServer.listener)
+
+    await hapiServer.start()
+
+    serverUrl = `http://localhost:${hapiServer.settings.port}${graphqlPath}`
+    t.context.helper = helper
+    t.context.serverUrl = serverUrl
+  })
+
+  t.afterEach((done) => {
+    hapiServer && hapiServer.stop()
+    server && server.stop()
+
+    helper.unload()
+    server = null
+    serverUrl = null
+    helper = null
+
+    clearCachedModules(['@hapi/hapi', 'apollo-server-hapi'], () => {
+      done()
+    })
+  })
+
+  createErrorTests(t)
+})
+
+function clearCachedModules(modules, callback) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+
+  callback()
+}

--- a/tests/versioned/apollo-server-hapi/package.json
+++ b/tests/versioned/apollo-server-hapi/package.json
@@ -13,7 +13,8 @@
       },
       "files": [
         "segments.tests.js",
-        "transaction-naming.test.js"
+        "transaction-naming.test.js",
+        "errors.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server/errors.test.js
+++ b/tests/versioned/apollo-server/errors.test.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const utils = require('@newrelic/test-utilities')
+const { getTypeDefs, resolvers } = require('../data-definitions')
+const { createErrorTests } = require('../errors-tests')
+
+tap.test('apollo-server: errors', (t) => {
+  t.autoend()
+
+  let server = null
+  let serverUrl = null
+  let helper = null
+
+  t.beforeEach((done) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented({
+      distributed_tracing: { enabled: true } // enable span testing
+    })
+    const createPlugin = require('../../../lib/create-plugin')
+    const nrApi = helper.getAgentApi()
+
+    // TODO: eventually use proper function for instrumenting and not .shim
+    const plugin = createPlugin(nrApi.shim)
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const { ApolloServer, gql } = require('apollo-server')
+    server = new ApolloServer({
+      typeDefs: getTypeDefs(gql),
+      resolvers,
+      plugins: [plugin]
+    })
+
+    server.listen().then(({ url }) => {
+      serverUrl = url
+
+      t.context.helper = helper
+      t.context.serverUrl = serverUrl
+      done()
+    })
+  })
+
+  t.afterEach((done) => {
+    server.stop()
+
+    helper.unload()
+    server = null
+    serverUrl = null
+    helper = null
+
+    clearCachedModules(['express', 'apollo-server'], () => {
+      done()
+    })
+  })
+
+  createErrorTests(t)
+})
+
+function clearCachedModules(modules, callback) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+
+  callback()
+}

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -13,7 +13,8 @@
       "files": [
         "transaction-naming.test.js",
         "segments.test.js",
-        "agent-disabled.test.js"
+        "agent-disabled.test.js",
+        "errors.test.js"
       ]
     }
   ],

--- a/tests/versioned/data-definitions.js
+++ b/tests/versioned/data-definitions.js
@@ -34,6 +34,7 @@ function getTypeDefs(gql) {
     type Library {
       branch: String!
       books: [Book!]
+      boom: String
     }
 
     type Book {
@@ -49,6 +50,7 @@ function getTypeDefs(gql) {
     type Query {
       books: [Book]
       hello: String
+      boom: String
       paramQuery(blah: String!, blee: String): String!
       libraries: [Library]
       library(branch: String!): [Library]
@@ -65,6 +67,9 @@ const resolvers = {
   Query: {
     hello: () => {
       return 'hello world'
+    },
+    boom: () => {
+      throw new Error('Boom goes the dynamite!')
     },
     paramQuery: (_, {blah, blee}) => {
       return blah + blee

--- a/tests/versioned/errors-tests.js
+++ b/tests/versioned/errors-tests.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { executeQuery } = require('./test-client')
+const agentTesting = require('./agent-testing')
+
+const ANON_PLACEHOLDER = '<anonymous>'
+const UNKNOWN_OPERATION_PLACEHOLDER = '<operation unknown>'
+
+/**
+ * Creates a set of standard error capture tests to run against various
+ * apollo-server libraries.
+ * It is required that t.context.helper and t.context.serverUrl are set.
+ * @param {*} t a tap test instance
+ */
+function createErrorTests(t) {
+  t.test('parsing error should be noticed and assigned to operation span', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedErrorMessage = 'Syntax Error: Expected Name, found <EOF>.'
+    const expectedErrorType = 'GraphQLError'
+
+    const invalidQuery = `query {
+      libraries {
+        books {
+          title
+          author {
+            name
+          }
+        }
+      }
+    ` // missing closing }
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const errorTraces = agentTesting.getErrorTraces(helper.agent)
+      t.equal(errorTraces.length, 1)
+
+      const errorTrace = errorTraces[0]
+
+      const [, transactionName, errorMessage, errorType, params] = errorTrace
+      t.equal(transactionName, transaction.name)
+      t.equal(errorMessage, expectedErrorMessage)
+      t.equal(errorType, expectedErrorType)
+
+      const { agentAttributes } = params
+
+      t.ok(agentAttributes.spanId)
+
+      const matchingSpan = agentTesting.findSpanById(helper.agent, agentAttributes.spanId)
+
+      const {attributes, intrinsics} = matchingSpan
+      t.equal(intrinsics.name, UNKNOWN_OPERATION_PLACEHOLDER)
+      t.equal(attributes['error.message'], expectedErrorMessage)
+      t.equal(attributes['error.class'], expectedErrorType)
+    })
+
+    executeQuery(serverUrl, invalidQuery, (err, result) => {
+      t.error(err)
+
+      t.ok(result)
+      t.ok(result.errors)
+      t.equal(result.errors.length, 1) // should have one parsing error
+
+      const [parseError] = result.errors
+      t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
+
+      t.end()
+    })
+  })
+
+  t.test('validation error should be noticed and assigned to operation span', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedErrorMessage = 'Cannot query field "doesnotexist" on type "Book".'
+    const expectedErrorType = 'GraphQLError'
+
+    const invalidQuery = `query {
+      libraries {
+        books {
+          title
+          doesnotexist {
+            name
+          }
+        }
+      }
+    }`
+
+    const expectedOperationName = `query ${ANON_PLACEHOLDER}`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const errorTraces = agentTesting.getErrorTraces(helper.agent)
+      t.equal(errorTraces.length, 1)
+
+      const errorTrace = errorTraces[0]
+
+      const [, transactionName, errorMessage, errorType, params] = errorTrace
+      t.equal(transactionName, transaction.name)
+      t.equal(errorMessage, expectedErrorMessage)
+      t.equal(errorType, expectedErrorType)
+
+      const { agentAttributes } = params
+
+      t.ok(agentAttributes.spanId)
+
+      const matchingSpan = agentTesting.findSpanById(helper.agent, agentAttributes.spanId)
+
+      const {attributes, intrinsics} = matchingSpan
+      t.equal(intrinsics.name, expectedOperationName)
+      t.equal(attributes['error.message'], expectedErrorMessage)
+      t.equal(attributes['error.class'], expectedErrorType)
+    })
+
+    executeQuery(serverUrl, invalidQuery, (err, result) => {
+      t.error(err)
+
+      t.ok(result)
+      t.ok(result.errors)
+      t.equal(result.errors.length, 1) // should have one parsing error
+
+      const [validationError] = result.errors
+      t.equal(validationError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
+
+      t.end()
+    })
+  })
+
+  t.test('resolver error should be noticed and assigned to resolve span', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedErrorMessage = 'Boom goes the dynamite!'
+    const expectedErrorType = 'Error'
+
+    const expectedName = 'BOOM'
+    const invalidQuery = `query ${expectedName} {
+      boom
+    }`
+
+    const expectedResolveName = 'resolve: boom'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const errorTraces = agentTesting.getErrorTraces(helper.agent)
+      t.equal(errorTraces.length, 1)
+
+      const errorTrace = errorTraces[0]
+
+      const [, transactionName, errorMessage, errorType, params] = errorTrace
+      t.equal(transactionName, transaction.name)
+      t.equal(errorMessage, expectedErrorMessage)
+      t.equal(errorType, expectedErrorType)
+
+      const { agentAttributes } = params
+
+      t.ok(agentAttributes.spanId)
+
+      const matchingSpan = agentTesting.findSpanById(helper.agent, agentAttributes.spanId)
+
+      const {attributes, intrinsics} = matchingSpan
+      t.equal(intrinsics.name, expectedResolveName)
+      t.equal(attributes['error.message'], expectedErrorMessage)
+      t.equal(attributes['error.class'], expectedErrorType)
+    })
+
+    executeQuery(serverUrl, invalidQuery, (err, result) => {
+      t.error(err)
+
+      t.ok(result)
+      t.ok(result.errors)
+      t.equal(result.errors.length, 1) // should have one parsing error
+
+      const [resolverError] = result.errors
+      t.equal(resolverError.extensions.code, 'INTERNAL_SERVER_ERROR')
+
+      t.end()
+    })
+  })
+}
+
+
+module.exports = {
+  createErrorTests
+}

--- a/tests/versioned/express-segments-tests.js
+++ b/tests/versioned/express-segments-tests.js
@@ -11,8 +11,8 @@ const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION_PLACEHOLDER = '<operation unknown>'
 
 /**
- * Creates a set of standard transction tests to run against various
- * apollo-server libraries.
+ * Creates a set of standard segment naming and nesting tests to run
+ * against express-based apollo-server libraries.
  * It is required that t.context.helper and t.context.serverUrl are set.
  * @param {*} t a tap test instance
  */


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Errors will now be assigned to either the appropriate resolver span or the operation span for all other errors.

Since the end resolve handler will invoke before the error catch-all, had to add resolve errors at that point and then flag them as not to double-add. Its an awkward dance, but having a catch-all is kinda nice to not have to litter handlers everywhere and potentially miss a case. If it ever turns out there could be a ton of noticed errors... we might want to rethink the current implementation as it iterates an array (that should be very small).
