### PR TITLE
Add segment span attributes

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -10,6 +10,22 @@ const errorHelper = new ErrorHelper()
 
 const NOTICED_ERRORS = ErrorHelper.NOTICED_ERRORS
 
+const ANON_PLACEHOLDER = '<anonymous>'
+const UNKNOWN_OPERATION = '<operation unknown>'
+
+const FIELD_NAME_ATTR = 'graphql.field.name'
+const RETURN_TYPE_ATTR = 'graphql.field.returnType'
+const PARENT_TYPE_ATTR = 'graphql.field.parentType'
+const FIELD_PATH_ATTR = 'graphql.field.path'
+const FIELD_ARGS_ATTR = 'graphql.field.args'
+const OPERATION_TYPE_ATTR = 'graphql.operation.type'
+const OPERATION_NAME_ATTR = 'graphql.operation.name'
+const OPERATION_PATH_ATTR = 'graphql.operation.deepestPath'
+
+const DESTINATIONS = {
+  NONE: 0x00
+}
+
 function createPlugin(instrumentationApi) {
   if (!instrumentationApi) {
     return {}
@@ -22,12 +38,12 @@ function createPlugin(instrumentationApi) {
       // We do not set to active here as batched queries will hit this
       // back to back and we'd prefer those not nest with each-other.
       const operationSegment = instrumentationApi.createSegment(
-        '<operation unknown>',
+        UNKNOWN_OPERATION,
         requestParent
       )
       operationSegment.start()
 
-      const longestResolvedPath = {
+      const deepestResolvedPath = {
         depth: 0,
         formatted: null
       }
@@ -46,7 +62,7 @@ function createPlugin(instrumentationApi) {
         },
         executionDidStart() {
           return {
-            willResolveField({info}) {
+            willResolveField({args, info}) {
               const currentSeg = instrumentationApi.getActiveSegment()
 
               // Nest everything under operation as resolvers start/finish
@@ -65,9 +81,24 @@ function createPlugin(instrumentationApi) {
 
               resolverSegment.name = `resolve: ${formattedPath}`
 
-              if (pathArray.length > longestResolvedPath.depth) {
-                longestResolvedPath.depth = pathArray.length
-                longestResolvedPath.formatted = formattedPath
+              if (pathArray.length > deepestResolvedPath.depth) {
+                deepestResolvedPath.depth = pathArray.length
+                deepestResolvedPath.formatted = formattedPath
+              }
+              resolverSegment.addAttribute(FIELD_PATH_ATTR, formattedPath)
+              resolverSegment.addAttribute(FIELD_NAME_ATTR, info.fieldName)
+              resolverSegment.addAttribute(RETURN_TYPE_ATTR, info.returnType.toString())
+              resolverSegment.addAttribute(PARENT_TYPE_ATTR, info.parentType.toString())
+
+
+              for (const [key, value] of Object.entries(args)) {
+                // Require adding to attribute 'include' configuration
+                // so as not to accidentally send senstive info to New Relic.
+                resolverSegment.attributes.addAttribute(
+                  DESTINATIONS.NONE,
+                  `${FIELD_ARGS_ATTR}.${key}`,
+                  value
+                )
               }
 
               return (error) => {
@@ -89,32 +120,32 @@ function createPlugin(instrumentationApi) {
         willSendResponse(responseContext) {
           // default. only used if failed to parse
           let transactionName = '*'
-          let segmentName = '<operation unknown>'
+          let segmentName = UNKNOWN_OPERATION
 
-          if (responseContext.operation) {
-            // Resolved operation: parsed and validated, will execute resolvers
+          const operationDetails
+            = getOperationDetails(responseContext, deepestResolvedPath.formatted)
 
-            const operationType = responseContext.operation.operation
-            const operationName = responseContext.operationName || '<anonymous>'
-            const longestPath = longestResolvedPath.formatted
+          if (operationDetails) {
+            const {operationName, operationType, deepestPath} = operationDetails
 
-            const operationDetails = `${operationType} ${operationName}`
+            operationSegment.addAttribute(OPERATION_TYPE_ATTR, operationType)
 
-            segmentName = operationDetails
-            transactionName = `${operationDetails} ${longestPath}`
-          } else if (responseContext.document) {
-            // Failed validation, fallback to document AST
+            if (operationName) {
+              operationSegment.addAttribute(OPERATION_NAME_ATTR, operationName)
+            }
 
-            const {
-              operationType,
-              operationName,
-              longestPath
-            } = getDetailsFromDocument(responseContext.document)
+            const formattedName = operationName || ANON_PLACEHOLDER
+            const formattedOperation = `${operationType} ${formattedName}`
 
-            const operationDetails = `${operationType} ${operationName}`
+            segmentName = formattedOperation
+            transactionName = formattedOperation
 
-            segmentName = operationDetails
-            transactionName = `${operationDetails} ${longestPath}`
+            // Certain requests, such as introspection, won't hit any resolvers
+            if (deepestPath) {
+              operationSegment.addAttribute(OPERATION_PATH_ATTR, deepestPath)
+
+              transactionName += ` ${deepestPath}`
+            }
           }
 
           setTransactionName(instrumentationApi.agent, transactionName)
@@ -127,16 +158,34 @@ function createPlugin(instrumentationApi) {
   }
 }
 
+function getOperationDetails(responseContext, deepestPath) {
+  if (responseContext.operation) {
+    // Resolved operation: parsed and validated, will execute resolvers
+
+    return {
+      operationName: responseContext.operationName,
+      operationType: responseContext.operation.operation,
+      deepestPath: deepestPath
+    }
+  } else if (responseContext.document) {
+    // Failed validation, fallback to document AST
+
+    return getDetailsFromDocument(responseContext.document)
+  }
+
+  return null
+}
+
 function getDetailsFromDocument(document) {
   const definition = document.definitions[0]
 
-  const longestSelectionPath = getLongestSelectionPath(definition)
+  const deepestSelectionPath = getDeepestSelectionPath(definition)
   const definitionName = definition.name && definition.name.value
 
   return {
     operationType: definition.operation,
-    operationName: definitionName || '<anonymous>',
-    longestPath: longestSelectionPath.join('.')
+    operationName: definitionName,
+    deepestPath: deepestSelectionPath.join('.')
   }
 }
 
@@ -173,22 +222,22 @@ function setTransactionName(agent, name) {
 }
 
 /**
- * Returns the longest path as an array of parts
+ * Returns the deepest path as an array of parts
  * from an apollo-server document definition.
  */
-function getLongestSelectionPath(definition) {
-  let longestPath = null
+function getDeepestSelectionPath(definition) {
+  let deepestPath = null
 
   definition.selectionSet.selections.forEach((selection) => {
     searchSelection(selection)
   })
 
-  return longestPath
+  return deepestPath
 
   /**
    * Search each selection path until no-more sub-selections
-   * exist. If the curent path is longer than longestPath,
-   * longestPath is replaced.
+   * exist. If the curent path is deeper than deepestPath,
+   * deepestPath is replaced.
    */
   function searchSelection(selection, currentParts) {
     const parts = currentParts ? [...currentParts] : []
@@ -198,8 +247,8 @@ function getLongestSelectionPath(definition) {
       selection.selectionSet.selections.forEach((innerSelection) => {
         searchSelection(innerSelection, parts)
       })
-    } else if (!longestPath || parts.length > longestPath.length) {
-      longestPath = parts
+    } else if (!deepestPath || parts.length > deepestPath.length) {
+      deepestPath = parts
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -226,9 +226,9 @@
       }
     },
     "@newrelic/test-utilities": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-4.1.1.tgz",
-      "integrity": "sha512-NCTGxMtDOC6DGRKbROwLsWVmVGy9HS9Z6StgPdQqJhkz1c2yEgVp1APxWgRha6AWY5yW5lfYPNkO/R9I+i8W5A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-4.1.2.tgz",
+      "integrity": "sha512-Km+kAeNzgLodSjaEyW1bYh3a5mgIQVR2H9shHBN5+xvJi/bZFiXMHJT/8zsgQ3+uNEAgDR7Tll1xL3S4erfyKg==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=10.0.0"
   },
   "devDependencies": {
-    "@newrelic/test-utilities": "^4.1.1",
+    "@newrelic/test-utilities": "^4.1.2",
     "eslint": "^7.8.1",
     "newrelic": "^6.13.0",
     "tap": "^14.10.8"

--- a/tests/versioned/agent-testing.js
+++ b/tests/versioned/agent-testing.js
@@ -31,8 +31,25 @@ function findSpanById(agent, spanId) {
   return matchingSpan
 }
 
+function findSegmentByName(root, name) {
+  if (root.name === name) {
+    return root
+  } else if (root.children && root.children.length) {
+    for (let i = 0; i < root.children.length; i++) {
+      const child = root.children[i]
+      const found = findSegmentByName(child, name)
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return null
+}
+
 module.exports = {
   getErrorTraces,
   getSpanEvents,
-  findSpanById
+  findSpanById,
+  findSegmentByName
 }

--- a/tests/versioned/apollo-server-express/attributes.test.js
+++ b/tests/versioned/apollo-server-express/attributes.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const utils = require('@newrelic/test-utilities')
+utils.assert.extendTap(tap)
+
+const { getTypeDefs, resolvers } = require('../data-definitions')
+const { createAttributesTests } = require('../attributes-tests')
+
+tap.test('apollo-server-express: attributes', (t) => {
+  t.autoend()
+
+  let server = null
+  let expressServer = null
+  let serverUrl = null
+  let helper = null
+
+  t.beforeEach((done) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented()
+    const createPlugin = require('../../../lib/create-plugin')
+    const nrApi = helper.getAgentApi()
+
+    // TODO: eventually use proper function for instrumenting and not .shim
+    const plugin = createPlugin(nrApi.shim)
+
+    const express = require('express')
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const { ApolloServer, gql } = require('apollo-server-express')
+    server = new ApolloServer({
+      typeDefs: getTypeDefs(gql),
+      resolvers,
+      plugins: [plugin]
+    })
+
+    const app = express()
+    server.applyMiddleware({ app })
+
+    expressServer = app.listen(0, () => {
+      serverUrl = `http://localhost:${expressServer.address().port}${server.graphqlPath}`
+
+      t.context.helper = helper
+      t.context.serverUrl = serverUrl
+      done()
+    })
+  })
+
+  t.afterEach((done) => {
+    expressServer && expressServer.close()
+    server && server.stop()
+
+    helper.unload()
+    server = null
+    serverUrl = null
+    helper = null
+
+    clearCachedModules(['express', 'apollo-server-express'], () => {
+      done()
+    })
+  })
+
+  createAttributesTests(t)
+})
+
+function clearCachedModules(modules, callback) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+
+  callback()
+}

--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -14,7 +14,8 @@
       "files": [
         "transaction-naming.test.js",
         "segments.test.js",
-        "errors.test.js"
+        "errors.test.js",
+        "attributes.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-hapi/attributes.test.js
+++ b/tests/versioned/apollo-server-hapi/attributes.test.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const utils = require('@newrelic/test-utilities')
+const { getTypeDefs, resolvers } = require('../data-definitions')
+const { createAttributesTests } = require('../attributes-tests')
+
+tap.test('apollo-server-hapi: attributes', (t) => {
+  t.autoend()
+
+  let server = null
+  let hapiServer = null
+  let serverUrl = null
+  let helper = null
+
+  t.beforeEach(async () => {
+    // load default instrumentation. hapi being critical
+    helper = utils.TestAgent.makeInstrumented()
+    const createPlugin = require('../../../lib/create-plugin')
+    const nrApi = helper.getAgentApi()
+
+    // TODO: eventually use proper function for instrumenting and not .shim
+    const plugin = createPlugin(nrApi.shim)
+
+    const Hapi = require('@hapi/hapi')
+
+    const graphqlPath = '/gql'
+
+    // Do after instrumentation to ensure hapi isn't loaded too soon.
+    const { ApolloServer, gql } = require('apollo-server-hapi')
+    server = new ApolloServer({
+      typeDefs: getTypeDefs(gql),
+      resolvers,
+      plugins: [plugin]
+    })
+
+    hapiServer = Hapi.server({
+      host: 'localhost',
+      port: 5000
+    })
+
+    await server.applyMiddleware({ app: hapiServer, path: graphqlPath })
+
+    await server.installSubscriptionHandlers(hapiServer.listener)
+
+    await hapiServer.start()
+
+    serverUrl = `http://localhost:${hapiServer.settings.port}${graphqlPath}`
+    t.context.helper = helper
+    t.context.serverUrl = serverUrl
+  })
+
+  t.afterEach((done) => {
+    hapiServer && hapiServer.stop()
+    server && server.stop()
+
+    helper.unload()
+    server = null
+    serverUrl = null
+    helper = null
+
+    clearCachedModules(['@hapi/hapi', 'apollo-server-hapi'], () => {
+      done()
+    })
+  })
+
+  createAttributesTests(t)
+})
+
+function clearCachedModules(modules, callback) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+
+  callback()
+}

--- a/tests/versioned/apollo-server-hapi/package.json
+++ b/tests/versioned/apollo-server-hapi/package.json
@@ -12,9 +12,10 @@
         "@hapi/hapi": "18.4.1"
       },
       "files": [
-        "segments.tests.js",
+        "segments.test.js",
         "transaction-naming.test.js",
-        "errors.test.js"
+        "errors.test.js",
+        "attributes.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-hapi/segments.test.js
+++ b/tests/versioned/apollo-server-hapi/segments.test.js
@@ -23,7 +23,7 @@ tap.test('apollo-server-hapi: segments', (t) => {
   let hapiServer = null
   let serverUrl = null
   let helper = null
-  
+
   t.beforeEach(async () => {
     // load default instrumentation. hapi being critical
     helper = utils.TestAgent.makeInstrumented()
@@ -34,7 +34,7 @@ tap.test('apollo-server-hapi: segments', (t) => {
     const plugin = createPlugin(nrApi.shim)
 
     const Hapi = require('@hapi/hapi')
-    
+
     const graphqlPath = '/gql'
 
     // Do after instrumentation to ensure hapi isn't loaded too soon.
@@ -178,7 +178,7 @@ tap.test('apollo-server-hapi: segments', (t) => {
     })
   })
 
-  t.test('named query, multi-level should return longest path', (t) => {
+  t.test('named query, multi-level should return deepest path', (t) => {
     const expectedName = 'GetBooksByLibrary'
     const query = `query ${expectedName} {
       libraries {
@@ -191,12 +191,12 @@ tap.test('apollo-server-hapi: segments', (t) => {
       }
     }`
 
-    const longestPath = 'libraries.books.author.name'
+    const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
       const operationPart = `query ${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `WebTransaction/apollo-server/${operationPart} ${deepestPath}`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{

--- a/tests/versioned/apollo-server/attributes.test.js
+++ b/tests/versioned/apollo-server/attributes.test.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+
+const utils = require('@newrelic/test-utilities')
+utils.assert.extendTap(tap)
+
+const { getTypeDefs, resolvers } = require('../data-definitions')
+const { createAttributesTests } = require('../attributes-tests')
+
+tap.test('apollo-server: attributes', (t) => {
+  t.autoend()
+
+  let server = null
+  let serverUrl = null
+  let helper = null
+
+  t.beforeEach((done) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented()
+    const createPlugin = require('../../../lib/create-plugin')
+    const nrApi = helper.getAgentApi()
+
+    // TODO: eventually use proper function for instrumenting and not .shim
+    const plugin = createPlugin(nrApi.shim)
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const { ApolloServer, gql } = require('apollo-server')
+    server = new ApolloServer({
+      typeDefs: getTypeDefs(gql),
+      resolvers,
+      plugins: [plugin]
+    })
+
+    server.listen().then(({ url }) => {
+      serverUrl = url
+
+      t.context.helper = helper
+      t.context.serverUrl = serverUrl
+      done()
+    })
+  })
+
+  t.afterEach((done) => {
+    server.stop()
+
+    helper.unload()
+    server = null
+    serverUrl = null
+    helper = null
+
+    clearCachedModules(['express', 'apollo-server'], () => {
+      done()
+    })
+  })
+
+  createAttributesTests(t)
+})
+
+function clearCachedModules(modules, callback) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+
+  callback()
+}

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -14,7 +14,8 @@
         "transaction-naming.test.js",
         "segments.test.js",
         "agent-disabled.test.js",
-        "errors.test.js"
+        "errors.test.js",
+        "attributes.test.js"
       ]
     }
   ],

--- a/tests/versioned/attributes-tests.js
+++ b/tests/versioned/attributes-tests.js
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { executeQuery, executeJson } = require('./test-client')
+const { findSegmentByName } = require('./agent-testing')
+
+const SEGMENT_DESTINATION = 0x20
+
+const ANON_PLACEHOLDER = '<anonymous>'
+
+/**
+ * Creates a set of standard attribute tests to run against various
+ * apollo-server libraries.
+ * It is required that t.context.helper and t.context.serverUrl are set.
+ * @param {*} t a tap test instance
+ */
+function createAttributesTests(t) {
+  t.test('anon query should capture standard attributes except operation name', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const query = `query {
+      hello
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+
+      const expectedOperationAttributes = {
+        'graphql.operation.type': 'query',
+        'graphql.operation.deepestPath': 'hello'
+      }
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        operationAttributes,
+        expectedOperationAttributes,
+        'should have operation attributes'
+      )
+
+      const hasAttribute = Object.hasOwnProperty.bind(operationAttributes)
+      t.notOk(hasAttribute('graphql.operation.name'))
+
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const expectedResolveAttributes = {
+        'graphql.field.name': 'hello',
+        'graphql.field.returnType': 'String',
+        'graphql.field.parentType': 'Query',
+        'graphql.field.path': 'hello'
+      }
+
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveAttributes,
+        expectedResolveAttributes,
+        'should have field resolve attributes'
+      )
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query should capture all standard attributes', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'HeyThere'
+    const query = `query ${expectedName} {
+      hello
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query ${expectedName}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+
+      const expectedOperationAttributes = {
+        'graphql.operation.type': 'query',
+        'graphql.operation.name': expectedName,
+        'graphql.operation.deepestPath': 'hello'
+      }
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        operationAttributes,
+        expectedOperationAttributes,
+        'should have operation attributes'
+      )
+
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const expectedResolveAttributes = {
+        'graphql.field.name': 'hello',
+        'graphql.field.returnType': 'String',
+        'graphql.field.parentType': 'Query',
+        'graphql.field.path': 'hello'
+      }
+
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveAttributes,
+        expectedResolveAttributes,
+        'should have field resolve attributes'
+      )
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query, multi-level, should capture deepest path', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBooksByLibrary'
+    const query = `query ${expectedName} {
+      libraries {
+        books {
+          title
+          author {
+            name
+          }
+        }
+      }
+    }`
+
+    const deepestPath = 'libraries.books.author.name'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query ${expectedName}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+
+      const expectedOperationAttributes = {
+        'graphql.operation.type': 'query',
+        'graphql.operation.name': expectedName,
+        'graphql.operation.deepestPath': deepestPath
+      }
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        operationAttributes,
+        expectedOperationAttributes,
+        'should have operation attributes'
+      )
+
+      const [resolveLibrariesSegment, resolveBooksSegment] = operationSegment.children
+
+      const expectedLibrariesAttributes = {
+        'graphql.field.name': 'libraries',
+        'graphql.field.returnType': '[Library]',
+        'graphql.field.parentType': 'Query',
+        'graphql.field.path': 'libraries'
+      }
+
+      const resolveLibrariesAttributes
+         = resolveLibrariesSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveLibrariesAttributes,
+        expectedLibrariesAttributes,
+        'should have field resolve attributes for libraries'
+      )
+
+      const expectedBooksAttributes = {
+        'graphql.field.name': 'books',
+        'graphql.field.returnType': '[Book!]',
+        'graphql.field.parentType': 'Library',
+        'graphql.field.path': 'libraries.book'
+      }
+
+      const resolveBooksAttributes
+         = resolveBooksSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveBooksAttributes,
+        expectedBooksAttributes,
+        'should have field resolve attributes for books'
+      )
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named mutation should capture all standard attributes', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'AddThing'
+    const query = `mutation ${expectedName} {
+      addThing(name: "added thing!")
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `mutation ${expectedName}`
+
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+
+      const expectedOperationAttributes = {
+        'graphql.operation.type': 'mutation',
+        'graphql.operation.name': expectedName,
+        'graphql.operation.deepestPath': 'addThing'
+      }
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        operationAttributes,
+        expectedOperationAttributes,
+        'should have operation attributes'
+      )
+
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const expectedResolveAttributes = {
+        'graphql.field.name': 'addThing',
+        'graphql.field.returnType': 'String',
+        'graphql.field.parentType': 'Mutation',
+        'graphql.field.path': 'addThing'
+      }
+
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveAttributes,
+        expectedResolveAttributes,
+        'should have field resolve attributes'
+      )
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named mutation should not capture args by default', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'AddThing'
+    const query = `mutation ${expectedName} {
+      addThing(name: "added thing!")
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `mutation ${expectedName}`
+
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+
+      const hasAttribute = Object.hasOwnProperty.bind(resolveAttributes)
+      t.notOk(hasAttribute('graphql.field.args.name'))
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named mutation should capture args when added to include list', (t) => {
+    const { helper, serverUrl } = t.context
+
+    helper.agent.config.attributes.include = ['graphql.field.args.*']
+    helper.agent.config.emit('attributes.include')
+
+    const expectedName = 'AddThing'
+    const query = `mutation ${expectedName} {
+      addThing(name: "added thing!")
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `mutation ${expectedName}`
+
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(resolveAttributes, {'graphql.field.args.name': 'added thing!'})
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query should capture args when added to include list', (t) => {
+    const { helper, serverUrl } = t.context
+
+    helper.agent.config.attributes.include = ['graphql.field.args.*']
+    helper.agent.config.emit('attributes.include')
+
+    const expectedName = 'BlahQuery'
+    const query = `query ${expectedName} {
+      paramQuery(blah: "first", blee: "second")
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query ${expectedName}`
+
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const expectedArgAttributes = {
+        'graphql.field.args.blah': 'first',
+        'graphql.field.args.blee': 'second'
+      }
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(resolveAttributes, expectedArgAttributes)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('query with variables should capture args when added to include list', (t) => {
+    const { helper, serverUrl } = t.context
+
+    helper.agent.config.attributes.include = ['graphql.field.args.*']
+    helper.agent.config.emit('attributes.include')
+
+    const expectedName = 'ParamQueryWithArgs'
+    const query = `query ${expectedName}($arg1: String!, $arg2: String) {
+      paramQuery(blah: $arg1, blee: $arg2)
+    }`
+
+    const queryJson = {
+      operationName: expectedName,
+      query: query,
+      variables: {
+        arg1: 'first',
+        arg2: 'second'
+      }
+    }
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query ${expectedName}`
+
+      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const resolveHelloSegment = operationSegment.children[0]
+
+      const expectedArgAttributes = {
+        'graphql.field.args.blah': 'first',
+        'graphql.field.args.blee': 'second'
+      }
+      const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(resolveAttributes, expectedArgAttributes)
+    })
+
+    executeJson(serverUrl, queryJson, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+}
+
+module.exports = {
+  createAttributesTests
+}

--- a/tests/versioned/express-segments-tests.js
+++ b/tests/versioned/express-segments-tests.js
@@ -138,7 +138,7 @@ function createSegmentsTests(t) {
     })
   })
 
-  t.test('named query, multi-level should return longest path', (t) => {
+  t.test('named query, multi-level should return deepest path', (t) => {
     const { helper, serverUrl } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -153,12 +153,12 @@ function createSegmentsTests(t) {
       }
     }`
 
-    const longestPath = 'libraries.books.author.name'
+    const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
       const operationPart = `query ${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `WebTransaction/apollo-server/${operationPart} ${deepestPath}`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{

--- a/tests/versioned/test-client.js
+++ b/tests/versioned/test-client.js
@@ -26,8 +26,17 @@ function executeQueryBatch(url, queries, callback) {
  * Data will be sent up in form { query: <input> }
  */
 function executeQuery(url, query, callback) {
-  let postData = JSON.stringify({ query })
+  const postData = JSON.stringify({ query })
 
+  makeRequest(url, postData, callback)
+}
+
+/**
+ * Execute a GraphQL POST request with the given JSON.
+ * Data will not be modified other than stringifying.
+ */
+function executeJson(url, json, callback) {
+  const postData = JSON.stringify(json)
   makeRequest(url, postData, callback)
 }
 
@@ -63,6 +72,7 @@ function makeRequest(url, postData, callback) {
 }
 
 module.exports = {
+  executeJson,
   executeQuery,
   executeQueryBatch
 }

--- a/tests/versioned/transaction-tests.js
+++ b/tests/versioned/transaction-tests.js
@@ -61,7 +61,7 @@ function createTransactionTests(t) {
     })
   })
 
-  t.test('anonymous query, multi-level should return longest path', (t) => {
+  t.test('anonymous query, multi-level should return deepest path', (t) => {
     const { helper, serverUrl } = t.context
 
     const query = `query {
@@ -75,12 +75,12 @@ function createTransactionTests(t) {
       }
     }`
 
-    const longestPath = 'libraries.books.author.name'
+    const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${ANON_PLACEHOLDER} ${longestPath}`
+        `WebTransaction/apollo-server/query ${ANON_PLACEHOLDER} ${deepestPath}`
       )
     })
 
@@ -92,7 +92,7 @@ function createTransactionTests(t) {
     })
   })
 
-  t.test('named query, multi-level should return longest path', (t) => {
+  t.test('named query, multi-level should return deepest path', (t) => {
     const { helper, serverUrl } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -107,12 +107,12 @@ function createTransactionTests(t) {
       }
     }`
 
-    const longestPath = 'libraries.books.author.name'
+    const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} ${longestPath}`
+        `WebTransaction/apollo-server/query ${expectedName} ${deepestPath}`
       )
     })
 
@@ -245,7 +245,7 @@ function createTransactionTests(t) {
     })
   })
 
-  t.test('named query, with params, should return longest path', (t) => {
+  t.test('named query, with params, should return deepest path', (t) => {
     const { helper, serverUrl } = t.context
 
     const expectedName = 'GetBookForLibrary'
@@ -260,12 +260,12 @@ function createTransactionTests(t) {
       }
     }`
 
-    const longestPath = 'library.books.author.name'
+    const deepestPath = 'library.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} ${longestPath}`
+        `WebTransaction/apollo-server/query ${expectedName} ${deepestPath}`
       )
     })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

* Closes: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/20

## Details

Adds an initial set of operation and field resolve level attributes.

Field args are initially set to a destination of NONE so they do not show up unless explicitly enabled via attribute config include. We'll still want to discuss with security so they are aware and confident we are doing the right thing (we are).

Attribute names subject to change.
