### PR TITLE
Updates transaction and segment/span naming 

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -13,6 +13,12 @@ const NOTICED_ERRORS = ErrorHelper.NOTICED_ERRORS
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION = '<operation unknown>'
 
+const CATEGORY = 'GraphQL'
+const FRAMEWORK = 'ApolloServer'
+const OPERATION_PREFIX = CATEGORY + '/operation/' + FRAMEWORK
+const RESOLVE_PREFIX = CATEGORY + '/resolve/' + FRAMEWORK
+const BATCH_PREFIX = 'batch'
+
 const FIELD_NAME_ATTR = 'graphql.field.name'
 const RETURN_TYPE_ATTR = 'graphql.field.returnType'
 const PARENT_TYPE_ATTR = 'graphql.field.parentType'
@@ -69,7 +75,7 @@ function createPlugin(instrumentationApi) {
               // in order but instrumentation such as promise tracking might
               // try to treat as nested.
               const resolverSegment = instrumentationApi.createSegment(
-                `resolve: ${info.fieldName}`,
+                `${RESOLVE_PREFIX}/${info.fieldName}`,
                 operationSegment
               )
 
@@ -79,7 +85,7 @@ function createPlugin(instrumentationApi) {
               const pathArray = flattenToArray(info.path)
               const formattedPath = pathArray.reverse().join('.')
 
-              resolverSegment.name = `resolve: ${formattedPath}`
+              resolverSegment.name = `${RESOLVE_PREFIX}/${formattedPath}`
 
               if (pathArray.length > deepestResolvedPath.depth) {
                 deepestResolvedPath.depth = pathArray.length
@@ -135,7 +141,7 @@ function createPlugin(instrumentationApi) {
             }
 
             const formattedName = operationName || ANON_PLACEHOLDER
-            const formattedOperation = `${operationType} ${formattedName}`
+            const formattedOperation = `${operationType}/${formattedName}`
 
             segmentName = formattedOperation
             transactionName = formattedOperation
@@ -144,13 +150,13 @@ function createPlugin(instrumentationApi) {
             if (deepestPath) {
               operationSegment.addAttribute(OPERATION_PATH_ATTR, deepestPath)
 
-              transactionName += ` ${deepestPath}`
+              transactionName += `/${deepestPath}`
             }
           }
 
           setTransactionName(instrumentationApi.agent, transactionName)
 
-          operationSegment.name = segmentName
+          operationSegment.name = `${OPERATION_PREFIX}/${segmentName}`
           operationSegment.end()
         }
       }
@@ -203,22 +209,32 @@ function flattenToArray(fieldPath) {
   return pathArray
 }
 
-// TODO: setup so don't need special internals
-// forcing will prevent custom names via API from working
-function setTransactionName(agent, name) {
+function setTransactionName(agent, transactionName) {
   const transaction = agent.tracer.getTransaction()
 
-  // TODO: ideally set via normal framework mechanisms as naming gets resolved
-  const framework = 'apollo-server'
+  const nameState = transaction.nameState
+  if (!nameState.graphql) {
+    // Override previously set path stack set thus far by web framework.
+    nameState.setName(
+      nameState.prefix,
+      nameState.verb,
+      nameState.delimiter,
+      transactionName
+    )
 
-  if (!transaction.forceName) {
-    transaction.forceName = `${framework}/${name}`
-    return
+    // Indicate we've set a name via graphql and future attempts to name
+    // are a part of a batch query request to apollo.
+    nameState.graphql = true
+  } else {
+    // If this is a batch query, add 'batch' indicator to the first part of the
+    // name unless we've already done so processing a prior query in the batch.
+    const firstPart = nameState.pathStack[0]
+    if (firstPart.path !== BATCH_PREFIX) {
+      nameState.pathStack.unshift({path: BATCH_PREFIX, params: null})
+    }
+
+    nameState.appendPath(transactionName)
   }
-
-  transaction.forceName = transaction.forceName.replace(framework, `${framework}/batch`)
-  const batchName = `${transaction.forceName}/${name}`
-  transaction.forceName = batchName
 }
 
 /**

--- a/tests/versioned/apollo-server-express/apollo-server-express-setup.js
+++ b/tests/versioned/apollo-server-express/apollo-server-express-setup.js
@@ -12,6 +12,8 @@ utils.assert.extendTap(tap)
 
 const { getTypeDefs, resolvers } = require('../data-definitions')
 
+const WEB_FRAMEWORK = 'Expressjs'
+
 function setupApolloServerExpressTests({suiteName, createTests}, config) {
   tap.test(`apollo-server-express: ${suiteName}`, (t) => {
     t.autoend()
@@ -66,7 +68,7 @@ function setupApolloServerExpressTests({suiteName, createTests}, config) {
       })
     })
 
-    createTests(t)
+    createTests(t, WEB_FRAMEWORK)
   })
 }
 

--- a/tests/versioned/apollo-server-hapi/apollo-server-hapi-setup.js
+++ b/tests/versioned/apollo-server-hapi/apollo-server-hapi-setup.js
@@ -12,6 +12,8 @@ utils.assert.extendTap(tap)
 
 const { getTypeDefs, resolvers } = require('../data-definitions')
 
+const WEB_FRAMEWORK = 'Hapi'
+
 function setupApolloServerHapiTests({suiteName, createTests}, config) {
   tap.test(`apollo-server-hapi: ${suiteName}`, (t) => {
     t.autoend()
@@ -72,7 +74,7 @@ function setupApolloServerHapiTests({suiteName, createTests}, config) {
       })
     })
 
-    createTests(t)
+    createTests(t, WEB_FRAMEWORK)
   })
 }
 

--- a/tests/versioned/apollo-server-hapi/segments.test.js
+++ b/tests/versioned/apollo-server-hapi/segments.test.js
@@ -10,6 +10,9 @@ const { executeQuery, executeQueryBatch } = require('../test-client')
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION_PLACEHOLDER = '<operation unknown>'
 
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
+
 const { setupApolloServerHapiTests } = require('./apollo-server-hapi-setup')
 
 setupApolloServerHapiTests({
@@ -17,7 +20,9 @@ setupApolloServerHapiTests({
   createTests: createHapiSegmentsTests
 })
 
-function createHapiSegmentsTests(t) {
+function createHapiSegmentsTests(t, frameworkName) {
+  const TRANSACTION_PREFIX = `WebTransaction/${frameworkName}/POST`
+
   t.test('anonymous query, single level', (t) => {
     const { helper, serverUrl } = t.context
 
@@ -26,15 +31,15 @@ function createHapiSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} hello`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/hello`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [{
-              name: 'resolve: hello'
+              name: `${RESOLVE_PREFIX}/hello`
             }]
           }]
         }]
@@ -59,15 +64,15 @@ function createHapiSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} hello`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/hello`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [{
-              name: 'resolve: hello'
+              name: `${RESOLVE_PREFIX}/hello`
             }]
           }]
         }]
@@ -101,18 +106,18 @@ function createHapiSegmentsTests(t) {
     const longestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${longestPath}`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [
-              { name: 'resolve: libraries' },
-              { name: 'resolve: libraries.books' },
-              { name: 'resolve: libraries.books.author' },
-              { name: 'resolve: libraries.books.author.name' }
+              { name: `${RESOLVE_PREFIX}/libraries` },
+              { name: `${RESOLVE_PREFIX}/libraries.books` },
+              { name: `${RESOLVE_PREFIX}/libraries.books.author` },
+              { name: `${RESOLVE_PREFIX}/libraries.books.author.name` }
             ]
           }]
         }]
@@ -147,19 +152,19 @@ function createHapiSegmentsTests(t) {
     const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${deepestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${deepestPath}`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [
-              { name: 'resolve: libraries' },
-              { name: 'resolve: libraries.books' },
-              { name: 'resolve: libraries.books.title'},
-              { name: 'resolve: libraries.books.author' },
-              { name: 'resolve: libraries.books.author.name' }
+              { name: `${RESOLVE_PREFIX}/libraries` },
+              { name: `${RESOLVE_PREFIX}/libraries.books` },
+              { name: `${RESOLVE_PREFIX}/libraries.books.title` },
+              { name: `${RESOLVE_PREFIX}/libraries.books.author` },
+              { name: `${RESOLVE_PREFIX}/libraries.books.author.name` }
             ]
           }]
         }]
@@ -193,18 +198,18 @@ function createHapiSegmentsTests(t) {
     const firstLongestPath = 'libraries.books.title'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${firstLongestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${firstLongestPath}`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
-                { name: 'resolve: libraries' },
-                { name: 'resolve: libraries.books' },
-                { name: 'resolve: libraries.books.title' },
-                { name: 'resolve: libraries.books.isbn' }
+                { name: `${RESOLVE_PREFIX}/libraries` },
+                { name: `${RESOLVE_PREFIX}/libraries.books` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.title` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.isbn` }
               ]
             }]
         }]
@@ -229,15 +234,15 @@ function createHapiSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${ANON_PLACEHOLDER}`
+      const operationPart = `mutation/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} addThing`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/addThing`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [{
-              name: 'resolve: addThing',
+              name: `${RESOLVE_PREFIX}/addThing`,
               children: [{
                 name: 'timers.setTimeout',
                 children: [{
@@ -269,15 +274,15 @@ function createHapiSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${expectedName}`
+      const operationPart = `mutation/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} addThing`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/addThing`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [{
-              name: 'resolve: addThing',
+              name: `${RESOLVE_PREFIX}/addThing`,
               children: [{
                 name: 'timers.setTimeout',
                 children: [{
@@ -308,15 +313,15 @@ function createHapiSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} paramQuery`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/paramQuery`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [
-              { name: 'resolve: paramQuery' }
+              { name: `${RESOLVE_PREFIX}/paramQuery` }
             ]
           }]
         }]
@@ -342,15 +347,15 @@ function createHapiSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} paramQuery`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/paramQuery`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [
-              { name: 'resolve: paramQuery' }
+              { name: `${RESOLVE_PREFIX}/paramQuery` }
             ]
           }]
         }]
@@ -385,16 +390,16 @@ function createHapiSegmentsTests(t) {
     const longestPath = 'library.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${longestPath}`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart,
+            name: `${OPERATION_PREFIX}/${operationPart}`,
             children: [
               {
-                name: 'resolve: library',
+                name: `${RESOLVE_PREFIX}/library`,
                 children: [{
                   name: 'timers.setTimeout',
                   children: [{
@@ -402,10 +407,10 @@ function createHapiSegmentsTests(t) {
                   }]
                 }]
               },
-              { name: 'resolve: library.books' },
-              { name: 'resolve: library.books.title'},
-              { name: 'resolve: library.books.author' },
-              { name: 'resolve: library.books.author.name' }
+              { name: `${RESOLVE_PREFIX}/library.books` },
+              { name: `${RESOLVE_PREFIX}/library.books.title` },
+              { name: `${RESOLVE_PREFIX}/library.books.author` },
+              { name: `${RESOLVE_PREFIX}/library.books.author.name` }
             ]
           }]
         }]
@@ -446,12 +451,12 @@ function createHapiSegmentsTests(t) {
     const queries = [query1, query2]
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart1 = `query ${expectedName1}`
-      const expectedQuery1Name = `${operationPart1} ${longestPath1}`
-      const operationPart2 = `mutation ${ANON_PLACEHOLDER}`
-      const expectedQuery2Name = `${operationPart2} addThing`
+      const operationPart1 = `query/${expectedName1}`
+      const expectedQuery1Name = `${operationPart1}/${longestPath1}`
+      const operationPart2 = `mutation/${ANON_PLACEHOLDER}`
+      const expectedQuery2Name = `${operationPart2}/addThing`
 
-      const batchTransactionPrefix = 'WebTransaction/apollo-server/batch'
+      const batchTransactionPrefix = `${TRANSACTION_PREFIX}//batch`
 
       const expectedSegments = [{
         name: `${batchTransactionPrefix}/${expectedQuery1Name}/${expectedQuery2Name}`,
@@ -459,10 +464,10 @@ function createHapiSegmentsTests(t) {
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [
             {
-              name: operationPart1,
+              name: `${OPERATION_PREFIX}/${operationPart1}`,
               children: [
                 {
-                  name: 'resolve: library',
+                  name: `${RESOLVE_PREFIX}/library`,
                   children: [{
                     name: 'timers.setTimeout',
                     children: [{
@@ -470,16 +475,16 @@ function createHapiSegmentsTests(t) {
                     }]
                   }]
                 },
-                { name: 'resolve: library.books' },
-                { name: 'resolve: library.books.title'},
-                { name: 'resolve: library.books.author' },
-                { name: 'resolve: library.books.author.name' }
+                { name: `${RESOLVE_PREFIX}/library.books` },
+                { name: `${RESOLVE_PREFIX}/library.books.title` },
+                { name: `${RESOLVE_PREFIX}/library.books.author` },
+                { name: `${RESOLVE_PREFIX}/library.books.author.name` }
               ]
             },
             {
-              name: operationPart2,
+              name: `${OPERATION_PREFIX}/${operationPart2}`,
               children: [{
-                name: 'resolve: addThing',
+                name: `${RESOLVE_PREFIX}/addThing`,
                 children: [{
                   name: 'timers.setTimeout',
                   children: [{
@@ -521,13 +526,8 @@ function createHapiSegmentsTests(t) {
     ` // missing closing }
 
     helper.agent.on('transactionFinished', (transaction) => {
-      t.equal(
-        transaction.name,
-        'WebTransaction/apollo-server/*'
-      )
-
       const expectedSegments = [{
-        name: 'WebTransaction/apollo-server/*',
+        name: `${TRANSACTION_PREFIX}//*`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
@@ -572,13 +572,13 @@ function createHapiSegmentsTests(t) {
     const longestPath = 'libraries.books.doesnotexist.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${longestPath}`,
         children: [{
           name: 'Nodejs/Middleware/Hapi/handler//gql',
           children: [{
-            name: operationPart
+            name: `${OPERATION_PREFIX}/${operationPart}`
           }]
         }]
       }]

--- a/tests/versioned/apollo-server/apollo-server-setup.js
+++ b/tests/versioned/apollo-server/apollo-server-setup.js
@@ -12,6 +12,8 @@ utils.assert.extendTap(tap)
 
 const { getTypeDefs, resolvers } = require('../data-definitions')
 
+const WEB_FRAMEWORK = 'Expressjs'
+
 function setupApolloServerTests({suiteName, createTests}, config) {
   tap.test(`apollo-server: ${suiteName}`, (t) => {
     t.autoend()
@@ -58,7 +60,7 @@ function setupApolloServerTests({suiteName, createTests}, config) {
       })
     })
 
-    createTests(t)
+    createTests(t, WEB_FRAMEWORK)
   })
 }
 

--- a/tests/versioned/attributes-tests.js
+++ b/tests/versioned/attributes-tests.js
@@ -12,6 +12,8 @@ const SEGMENT_DESTINATION = 0x20
 
 const ANON_PLACEHOLDER = '<anonymous>'
 
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+
 /**
  * Creates a set of standard attribute tests to run against various
  * apollo-server libraries.
@@ -27,8 +29,8 @@ function createAttributesTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationName = `${OPERATION_PREFIX}/query/${ANON_PLACEHOLDER}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
 
       const expectedOperationAttributes = {
         'graphql.operation.type': 'query',
@@ -77,8 +79,8 @@ function createAttributesTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
 
       const expectedOperationAttributes = {
         'graphql.operation.type': 'query',
@@ -134,8 +136,8 @@ function createAttributesTests(t) {
     const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
 
       const expectedOperationAttributes = {
         'graphql.operation.type': 'query',
@@ -198,9 +200,9 @@ function createAttributesTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${expectedName}`
+      const operationName = `${OPERATION_PREFIX}/mutation/${expectedName}`
 
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
 
       const expectedOperationAttributes = {
         'graphql.operation.type': 'mutation',
@@ -247,9 +249,9 @@ function createAttributesTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${expectedName}`
+      const operationName = `${OPERATION_PREFIX}/mutation/${expectedName}`
 
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
       const resolveHelloSegment = operationSegment.children[0]
 
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
@@ -276,9 +278,9 @@ function createAttributesTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${expectedName}`
+      const operationName = `${OPERATION_PREFIX}/mutation/${expectedName}`
 
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
       const resolveHelloSegment = operationSegment.children[0]
 
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
@@ -303,9 +305,9 @@ function createAttributesTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}`
 
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
       const resolveHelloSegment = operationSegment.children[0]
 
       const expectedArgAttributes = {
@@ -343,9 +345,9 @@ function createAttributesTests(t) {
     }
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}`
 
-      const operationSegment = findSegmentByName(transaction.trace.root, operationPart)
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
       const resolveHelloSegment = operationSegment.children[0]
 
       const expectedArgAttributes = {

--- a/tests/versioned/errors-tests.js
+++ b/tests/versioned/errors-tests.js
@@ -11,6 +11,9 @@ const agentTesting = require('./agent-testing')
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION_PLACEHOLDER = '<operation unknown>'
 
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
+
 /**
  * Creates a set of standard error capture tests to run against various
  * apollo-server libraries.
@@ -53,7 +56,7 @@ function createErrorTests(t) {
       const matchingSpan = agentTesting.findSpanById(helper.agent, agentAttributes.spanId)
 
       const {attributes, intrinsics} = matchingSpan
-      t.equal(intrinsics.name, UNKNOWN_OPERATION_PLACEHOLDER)
+      t.equal(intrinsics.name, `${OPERATION_PREFIX}/${UNKNOWN_OPERATION_PLACEHOLDER}`)
       t.equal(attributes['error.message'], expectedErrorMessage)
       t.equal(attributes['error.class'], expectedErrorType)
     })
@@ -89,7 +92,7 @@ function createErrorTests(t) {
       }
     }`
 
-    const expectedOperationName = `query ${ANON_PLACEHOLDER}`
+    const expectedOperationName = `${OPERATION_PREFIX}/query/${ANON_PLACEHOLDER}`
 
     helper.agent.on('transactionFinished', (transaction) => {
       const errorTraces = agentTesting.getErrorTraces(helper.agent)
@@ -139,7 +142,7 @@ function createErrorTests(t) {
       boom
     }`
 
-    const expectedResolveName = 'resolve: boom'
+    const expectedResolveName = `${RESOLVE_PREFIX}/boom`
 
     helper.agent.on('transactionFinished', (transaction) => {
       const errorTraces = agentTesting.getErrorTraces(helper.agent)

--- a/tests/versioned/express-segments-tests.js
+++ b/tests/versioned/express-segments-tests.js
@@ -10,13 +10,18 @@ const { executeQuery, executeQueryBatch } = require('./test-client')
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION_PLACEHOLDER = '<operation unknown>'
 
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
+
 /**
  * Creates a set of standard segment naming and nesting tests to run
  * against express-based apollo-server libraries.
  * It is required that t.context.helper and t.context.serverUrl are set.
  * @param {*} t a tap test instance
  */
-function createSegmentsTests(t) {
+function createSegmentsTests(t, frameworkName) {
+  const TRANSACTION_PREFIX = `WebTransaction/${frameworkName}/POST`
+
   t.test('anonymous query, single level', (t) => {
     const { helper, serverUrl } = t.context
 
@@ -25,17 +30,17 @@ function createSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} hello`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/hello`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [{
-                name: 'resolve: hello'
+                name: `${RESOLVE_PREFIX}/hello`
               }]
             }]
           }]
@@ -62,17 +67,17 @@ function createSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} hello`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/hello`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [{
-                name: 'resolve: hello'
+                name: `${RESOLVE_PREFIX}/hello`
               }]
             }]
           }]
@@ -107,20 +112,20 @@ function createSegmentsTests(t) {
     const longestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${longestPath}`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
-                { name: 'resolve: libraries' },
-                { name: 'resolve: libraries.books' },
-                { name: 'resolve: libraries.books.author' },
-                { name: 'resolve: libraries.books.author.name' }
+                { name: `${RESOLVE_PREFIX}/libraries` },
+                { name: `${RESOLVE_PREFIX}/libraries.books` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.author` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.author.name` }
               ]
             }]
           }]
@@ -156,21 +161,21 @@ function createSegmentsTests(t) {
     const deepestPath = 'libraries.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${deepestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${deepestPath}`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
-                { name: 'resolve: libraries' },
-                { name: 'resolve: libraries.books' },
-                { name: 'resolve: libraries.books.title'},
-                { name: 'resolve: libraries.books.author' },
-                { name: 'resolve: libraries.books.author.name' }
+                { name: `${RESOLVE_PREFIX}/libraries` },
+                { name: `${RESOLVE_PREFIX}/libraries.books` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.title` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.author` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.author.name` }
               ]
             }]
           }]
@@ -205,20 +210,20 @@ function createSegmentsTests(t) {
     const firstLongestPath = 'libraries.books.title'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${firstLongestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${firstLongestPath}`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
-                { name: 'resolve: libraries' },
-                { name: 'resolve: libraries.books' },
-                { name: 'resolve: libraries.books.title' },
-                { name: 'resolve: libraries.books.isbn' }
+                { name: `${RESOLVE_PREFIX}/libraries` },
+                { name: `${RESOLVE_PREFIX}/libraries.books` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.title` },
+                { name: `${RESOLVE_PREFIX}/libraries.books.isbn` }
               ]
             }]
           }]
@@ -244,17 +249,17 @@ function createSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${ANON_PLACEHOLDER}`
+      const operationPart = `mutation/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} addThing`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/addThing`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [{
-                name: 'resolve: addThing',
+                name: `${RESOLVE_PREFIX}/addThing`,
                 children: [{
                   name: 'timers.setTimeout',
                   children: [{
@@ -287,17 +292,17 @@ function createSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `mutation ${expectedName}`
+      const operationPart = `mutation/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} addThing`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/addThing`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [{
-                name: 'resolve: addThing',
+                name: `${RESOLVE_PREFIX}/addThing`,
                 children: [{
                   name: 'timers.setTimeout',
                   children: [{
@@ -329,17 +334,17 @@ function createSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} paramQuery`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/paramQuery`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
-                { name: 'resolve: paramQuery' }
+                { name: `${RESOLVE_PREFIX}/paramQuery` }
               ]
             }]
           }]
@@ -366,17 +371,17 @@ function createSegmentsTests(t) {
     }`
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} paramQuery`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/paramQuery`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
-                { name: 'resolve: paramQuery' }
+                { name: `${RESOLVE_PREFIX}/paramQuery` }
               ]
             }]
           }]
@@ -412,18 +417,18 @@ function createSegmentsTests(t) {
     const longestPath = 'library.books.author.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${expectedName}`
+      const operationPart = `query/${expectedName}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${longestPath}`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart,
+              name: `${OPERATION_PREFIX}/${operationPart}`,
               children: [
                 {
-                  name: 'resolve: library',
+                  name: `${RESOLVE_PREFIX}/library`,
                   children: [{
                     name: 'timers.setTimeout',
                     children: [{
@@ -431,10 +436,10 @@ function createSegmentsTests(t) {
                     }]
                   }]
                 },
-                { name: 'resolve: library.books' },
-                { name: 'resolve: library.books.title'},
-                { name: 'resolve: library.books.author' },
-                { name: 'resolve: library.books.author.name' }
+                { name: `${RESOLVE_PREFIX}/library.books` },
+                { name: `${RESOLVE_PREFIX}/library.books.title` },
+                { name: `${RESOLVE_PREFIX}/library.books.author` },
+                { name: `${RESOLVE_PREFIX}/library.books.author.name` }
               ]
             }]
           }]
@@ -476,12 +481,12 @@ function createSegmentsTests(t) {
     const queries = [query1, query2]
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart1 = `query ${expectedName1}`
-      const expectedQuery1Name = `${operationPart1} ${longestPath1}`
-      const operationPart2 = `mutation ${ANON_PLACEHOLDER}`
-      const expectedQuery2Name = `${operationPart2} addThing`
+      const operationPart1 = `query/${expectedName1}`
+      const expectedQuery1Name = `${operationPart1}/${longestPath1}`
+      const operationPart2 = `mutation/${ANON_PLACEHOLDER}`
+      const expectedQuery2Name = `${operationPart2}/addThing`
 
-      const batchTransactionPrefix = 'WebTransaction/apollo-server/batch'
+      const batchTransactionPrefix = `${TRANSACTION_PREFIX}//batch`
 
       const expectedSegments = [{
         name: `${batchTransactionPrefix}/${expectedQuery1Name}/${expectedQuery2Name}`,
@@ -491,10 +496,10 @@ function createSegmentsTests(t) {
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [
               {
-                name: operationPart1,
+                name: `${OPERATION_PREFIX}/${operationPart1}`,
                 children: [
                   {
-                    name: 'resolve: library',
+                    name: `${RESOLVE_PREFIX}/library`,
                     children: [{
                       name: 'timers.setTimeout',
                       children: [{
@@ -502,16 +507,16 @@ function createSegmentsTests(t) {
                       }]
                     }]
                   },
-                  { name: 'resolve: library.books' },
-                  { name: 'resolve: library.books.title'},
-                  { name: 'resolve: library.books.author' },
-                  { name: 'resolve: library.books.author.name' }
+                  { name: `${RESOLVE_PREFIX}/library.books` },
+                  { name: `${RESOLVE_PREFIX}/library.books.title`},
+                  { name: `${RESOLVE_PREFIX}/library.books.author` },
+                  { name: `${RESOLVE_PREFIX}/library.books.author.name` }
                 ]
               },
               {
-                name: operationPart2,
+                name: `${OPERATION_PREFIX}/${operationPart2}`,
                 children: [{
-                  name: 'resolve: addThing',
+                  name: `${RESOLVE_PREFIX}/addThing`,
                   children: [{
                     name: 'timers.setTimeout',
                     children: [{
@@ -556,11 +561,11 @@ function createSegmentsTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        'WebTransaction/apollo-server/*'
+        `${TRANSACTION_PREFIX}//*`
       )
 
       const expectedSegments = [{
-        name: 'WebTransaction/apollo-server/*',
+        name: `${TRANSACTION_PREFIX}//*`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
@@ -608,15 +613,15 @@ function createSegmentsTests(t) {
     const longestPath = 'libraries.books.doesnotexist.name'
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const operationPart = `query ${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}`
       const expectedSegments = [{
-        name: `WebTransaction/apollo-server/${operationPart} ${longestPath}`,
+        name: `${TRANSACTION_PREFIX}//${operationPart}/${longestPath}`,
         children: [{
           name: 'Expressjs/Router: /',
           children: [{
             name: 'Nodejs/Middleware/Expressjs/<anonymous>',
             children: [{
-              name: operationPart
+              name: `${OPERATION_PREFIX}/${operationPart}`
             }]
           }]
         }]

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -15,7 +15,9 @@ const ANON_PLACEHOLDER = '<anonymous>'
  * It is required that t.context.helper and t.context.serverUrl are set.
  * @param {*} t a tap test instance
  */
-function createTransactionTests(t) {
+function createTransactionTests(t, frameworkName) {
+  const EXPECTED_PREFIX = `WebTransaction/${frameworkName}/POST`
+
   t.test('anonymous query, single level, should use anonymous placeholder', (t) => {
     const { helper, serverUrl } = t.context
 
@@ -26,7 +28,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${ANON_PLACEHOLDER} hello`
+        `${EXPECTED_PREFIX}//query/${ANON_PLACEHOLDER}/hello`
       )
     })
 
@@ -49,7 +51,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} hello`
+        `${EXPECTED_PREFIX}//query/${expectedName}/hello`
       )
     })
 
@@ -80,7 +82,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${ANON_PLACEHOLDER} ${deepestPath}`
+        `${EXPECTED_PREFIX}//query/${ANON_PLACEHOLDER}/${deepestPath}`
       )
     })
 
@@ -112,7 +114,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} ${deepestPath}`
+        `${EXPECTED_PREFIX}//query/${expectedName}/${deepestPath}`
       )
     })
 
@@ -143,7 +145,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} ${firstLongestPath}`
+        `${EXPECTED_PREFIX}//query/${expectedName}/${firstLongestPath}`
       )
     })
 
@@ -165,7 +167,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/mutation ${ANON_PLACEHOLDER} addThing`
+        `${EXPECTED_PREFIX}//mutation/${ANON_PLACEHOLDER}/addThing`
       )
     })
 
@@ -188,7 +190,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/mutation ${expectedName} addThing`
+        `${EXPECTED_PREFIX}//mutation/${expectedName}/addThing`
       )
     })
 
@@ -210,7 +212,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${ANON_PLACEHOLDER} paramQuery`
+        `${EXPECTED_PREFIX}//query/${ANON_PLACEHOLDER}/paramQuery`
       )
     })
 
@@ -233,7 +235,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} paramQuery`
+        `${EXPECTED_PREFIX}//query/${expectedName}/paramQuery`
       )
     })
 
@@ -265,7 +267,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} ${deepestPath}`
+        `${EXPECTED_PREFIX}//query/${expectedName}/${deepestPath}`
       )
     })
 
@@ -301,11 +303,11 @@ function createTransactionTests(t) {
     const queries = [query1, query2]
 
     helper.agent.on('transactionFinished', (transaction) => {
-      const expectedQuery1Name = `query ${expectedName1} ${longestPath1}`
-      const expectedQuery2Name = `mutation ${ANON_PLACEHOLDER} addThing`
+      const expectedQuery1Name = `query/${expectedName1}/${longestPath1}`
+      const expectedQuery2Name = `mutation/${ANON_PLACEHOLDER}/addThing`
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/batch/${expectedQuery1Name}/${expectedQuery2Name}`
+        `${EXPECTED_PREFIX}//batch/${expectedQuery1Name}/${expectedQuery2Name}`
       )
     })
 
@@ -335,10 +337,7 @@ function createTransactionTests(t) {
     ` // missing closing }
 
     helper.agent.on('transactionFinished', (transaction) => {
-      t.equal(
-        transaction.name,
-        'WebTransaction/apollo-server/*'
-      )
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//*`)
     })
 
     executeQuery(serverUrl, invalidQuery, (err, result) => {
@@ -376,7 +375,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${ANON_PLACEHOLDER} ${longestPath}`
+        `${EXPECTED_PREFIX}//query/${ANON_PLACEHOLDER}/${longestPath}`
       )
     })
 
@@ -416,7 +415,7 @@ function createTransactionTests(t) {
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(
         transaction.name,
-        `WebTransaction/apollo-server/query ${expectedName} ${longestPath}`
+        `${EXPECTED_PREFIX}//query/${expectedName}/${longestPath}`
       )
     })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

* Closes: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/31

## Details

Updates to more standard naming conventions that separate pieces by '/'.

Transactions will now be named based on the web framework, via web convention using the method/verb. We may decide to tweak that more over time.
