### PR TITLE
Update readme with plugin timings recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Other plugins may work, depending on their underlying implementation, but have n
 ### Interaction with other Apollo Plugins
 
 Transaction and segment/span timings may be affected by other plugins used in the Apollo Server setup. In order to get more accurate resolver timings, it is recommended to add the New Relic plugin last.
+
 ```
 const server = new ApolloServer({
   typeDefs,

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Other plugins may work, depending on their underlying implementation, but have n
 
 Transaction and segment/span timings may be affected by other plugins used in the Apollo Server setup. In order to get more accurate resolver timings, it is recommended to add the New Relic plugin last.
 
+
 ```
 const server = new ApolloServer({
   typeDefs,

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ Note: Because fastify is not fully instrumented in the Node.js Agent, transactio
 
 Other plugins may work, depending on their underlying implementation, but have not been verified.
 
+### Interaction with other Apollo Plugins
+
+Transaction and segment/span timings may be affected by other plugins used in the Apollo Server setup. In order to get more accurate resolver timings, it is recommended to add the New Relic plugin last.
+```
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  plugins: [
+    other_plugin,
+    newrelic_plugin
+  ]
+})
+```
 ### Configuration
 
 Configuration may be passed into the `createPlugin` function to override specific values. The configuration object and all properties are optional.


### PR DESCRIPTION
## Proposed Release Notes

## Links

## Details
Update readme with Apollo server setup recommendations when multiple plugins are in use.

Other plugins in the Apollo Server setup will affect the overall timings of a graphql request.  If the New Relic Apollo Plugin is last in the chain of plugins used, the field resolution timings will be more accurate.