### PR TITLE
Only set query attribute if it exists

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -166,12 +166,14 @@ function createPlugin(instrumentationApi, config = {}) {
           let segmentName = UNKNOWN_OPERATION
           let query = responseContext.request.query
 
-          // attempt to extract arguments to strip from query
-          query = cleanQuery(query)
+          if (query) {
+            // attempt to extract arguments to strip from query
+            query = cleanQuery(query)
 
-          operationSegment.addAttribute(
-            OPERATION_QUERY_ATTR,
-            query)
+            operationSegment.addAttribute(
+              OPERATION_QUERY_ATTR,
+              query)
+          }
 
           const operationDetails
             = getOperationDetails(responseContext, deepestResolvedPath.formatted)


### PR DESCRIPTION
## Proposed Release Notes
Fixed error when no query is provided

## Links
https://www.apollographql.com/docs/apollo-server/performance/apq/

## Details
In cases when apollo client is using persisted queries the query parameter is not sent in the request. In theory you could set the query has as an attribute but I just wanted to fix the 500 error.

This fixes a 500 error we had where cleanQuery was doing a regex on the value undefined.
```
TypeError: Cannot read property 'replace' of undefined
```