### PR TITLE
fix: package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@newrelic/apollo-server-plugin",
   "version": "0.1.3",
   "description": "Apollo Server plugin that adds New Relic Node.js agent instrumentation.",
-  "main": "/src/index.js",
+  "main": "./index.js",
   "scripts": {
     "integration": "rm -f newrelic_agent.log && time tap --test-regex='(\\/|^tests\\/integration\\/.*\\.test\\.js)$' --no-coverage",
     "lint": "eslint *.js lib tests",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

the `main` field in package.json is pointing to a wrong location.

**node.js v16+** prints a warning:

```
DeprecationWarning: Invalid 'main' field in '/node_modules/@newrelic/apollo-server-plugin/package.json' of '/src/index.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```

## Links

## Details
