### PR TITLE
Runs fastify versioned tests aonly against latest fastify version.

### DIFF
--- a/tests/versioned/apollo-server-fastify/package.json
+++ b/tests/versioned/apollo-server-fastify/package.json
@@ -9,7 +9,7 @@
       },
       "dependencies": {
         "apollo-server-fastify": ">=2.14.0",
-        "fastify": ">=3.5.0"
+        "fastify": "3.5.0"
       },
       "files": [
         "segments.test.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Pins fastify to a single version for apollo-server-fastify versioned testing.

## Links

## Details

We don't really need to be testing a big permutation of fastify itself, as our instrumentation is specific to the plugin. If something breaks with a fastify version, it is most likely going to be with the plugin framework or apollo-server-fastify. Drops permutations down to ~44 and reduces execution time by about 2/3.

Ideally, would prob use the latest version each run but I couldn't determine an obvious way to do that with the versioned framework right now and didn't want to invest a ton of time.
