### PR TITLE
Bump versioned test runner and prep for Node 16

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -72,5 +72,9 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm ci
-    - name: Run Versioned Tests
-      run: npm run versioned
+    - name: Run Versioned Tests (npm v6 / Node 10-14)
+      if: ${{ matrix.node-version != '16.x' }}
+      run: npm run versioned:npm6
+    - name: Run Versioned Tests (npm v7 / Node 16)
+      if: ${{ matrix.node-version == '16.x' }}
+      run: npm run versioned:npm7

--- a/package-lock.json
+++ b/package-lock.json
@@ -273,9 +273,9 @@
       }
     },
     "@newrelic/test-utilities": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-4.1.2.tgz",
-      "integrity": "sha512-Km+kAeNzgLodSjaEyW1bYh3a5mgIQVR2H9shHBN5+xvJi/bZFiXMHJT/8zsgQ3+uNEAgDR7Tll1xL3S4erfyKg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-5.1.0.tgz",
+      "integrity": "sha512-Z4W27G/ivPIVKA42liIQhnicuqA2Tqw62gkE2/tb92yZpZlyVLswqOovfM7/3vG3GuXJJ/mnceVMJYIC1MzRmw==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node": ">=10.0.0"
   },
   "devDependencies": {
-    "@newrelic/test-utilities": "^4.1.2",
+    "@newrelic/test-utilities": "^5.1.0",
     "apollo-server": "^2.18.2",
     "eslint": "^7.8.1",
     "newrelic": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "lint": "eslint *.js lib tests",
     "test": "npm run unit && npm run integration && npm run versioned",
     "unit": "tap --test-regex='(\\/|^tests\\/unit\\/.*\\.test\\.js)$' --no-coverage",
-    "versioned": "versioned-tests --minor -i 2 'tests/versioned/*'"
+    "versioned": "npm run versioned:npm6",
+    "versioned:npm6": "versioned-tests --minor -i 2 'tests/versioned/*'",
+    "versioned:npm7": "versioned-tests --minor --all -i 2 'tests/versioned/*'"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped @newrelic/test-utilities to ^5.1.0.

* Added npm scripts and GitHub actions plumbing to run versioned test runner with appropriate flags for npm v7 and npm v6.

  Node 16 ships with npm v7 which has several different behaviors than npm v6. Testing found we need to ensure all packages are installed for each versioned test permutation which is handled via the `--all` flag in the new version of the versioned test runner.

## Links

* Resolves some of the issues found in: https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/75

## Details

Wired up handling for Node 16 but not running against 16 as there are other issues to be resolved. This takes Bob's update to the versioned runner and hooks it up to help move the other PR(s) forward.
