### PR TITLE
updated NEWS for v0.2.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+## 0.2.0 (05/25/2021)
+* Added Node.js v16 to run CI pipeline steps
+* Fixed the main field in package.json to point to proper location
+
+  Thank you to @dnalborczyk for these contributions!
+
+* Pinned fastify to a single version for apollo-server-fastify versioned testing.
+* Upgraded tap and newrelic agent to latest
+* Added husky + lint-staged to run linting on staged files as a pre-commit hook
+* Pinned apollo-server-hapi versioned tests to only run on <16
+* Bumped `@newrelic/test-utilities` to `^5.1.0`
+* Added npm scripts and GitHub actions plumbing to run versioned test runner with appropriate flags for npm v7 and npm v6.
+
+  Node 16 ships with npm v7 which has several different behaviors than npm v6. Testing found we need to ensure all packages are installed for each versioned test permutation which is handled via the --all flag in the new version of the versioned test runner.
+
 ## 0.1.3 (02/24/2021)
 
 * Fixed issue where state loss introduced through another module could result in the plugin causing a query to error while trying to set the transaction name.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Added Node.js v16 to run CI pipeline steps
* Fixed the main field in package.json to point to proper location

  Thank you to @dnalborczyk for these contributions!

* Pinned fastify to a single version for apollo-server-fastify versioned testing.
* Upgraded tap and newrelic agent to latest
* Added husky + lint-staged to run linting on staged files as a pre-commit hook
* Pinned apollo-server-hapi versioned tests to only run on <16
* Bumped `@newrelic/test-utilities` to `^5.1.0`
* Added npm scripts and GitHub actions plumbing to run versioned test runner with appropriate flags for npm v7 and npm v6.

  Node 16 ships with npm v7 which has several different behaviors than npm v6. Testing found we need to ensure all packages are installed for each versioned test permutation which is handled via the --all flag in the new version of the versioned test runner.

## Links
 * #80 
 * #79 
 * #77 
 * #74
 * #72
 
## Details
