### PR TITLE
properly set query operation when executing a persisted query

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -184,7 +184,11 @@ function createPlugin(instrumentationApi, config = {}) {
           // default. only used if failed to parse
           let transactionName = '*'
           let segmentName = UNKNOWN_OPERATION
-          let query = responseContext.request.query
+
+          // if request was for a persistedQuery, the query lives on
+          // responseContext.source
+          // see: https://github.com/apollographql/apollo-server/blob/2bccec2c5f5adaaf785f13ab98b6e52e22d5b22e/packages/apollo-server-core/src/requestPipeline.ts#L232
+          let query = responseContext.request.query || responseContext.source
 
           if (query) {
             // attempt to extract arguments to strip from query

--- a/tests/agent-testing.js
+++ b/tests/agent-testing.js
@@ -51,7 +51,7 @@ function temporarySetEnv(t, key, value) {
   const existing = process.env[key]
   process.env[key] = value
 
-  t.tearDown(() => {
+  t.teardown(() => {
     if (existing === undefined) {
       delete process.env[key]
       return

--- a/tests/test-client.js
+++ b/tests/test-client.js
@@ -42,11 +42,15 @@ function executeJson(url, json, callback) {
 
 function makeRequest(url, postData, callback) {
   const options = {
-    method: 'POST',
+    method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(postData)
+      'Content-Type': 'application/json'
     }
+  }
+
+  if (postData) {
+    options.method = 'POST'
+    options.headers['Content-Length'] = Buffer.byteLength(postData)
   }
 
   const req = http.request(url, options, (res) => {
@@ -67,12 +71,15 @@ function makeRequest(url, postData, callback) {
     callback(e)
   })
 
-  req.write(postData)
+  if (postData) {
+    req.write(postData)
+  }
   req.end()
 }
 
 module.exports = {
   executeJson,
   executeQuery,
-  executeQueryBatch
+  executeQueryBatch,
+  makeRequest
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added support for capturing persisted queries

## Links
Closes #57 

## Details
The gist is shown in the new integration test I wrote but basically if you make a request with a query and the `persistedQuery` extension enabled with the appropriate sha256 hash of query and then make a subsequent request with the extension and sha256 without query it will properly pull it from the query cache and our `willSendResponse` hook point will properly pull the query from `context.source`