### PR TITLE
Provided a new config option to control ignoring transactions for

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To override configuration, invoke the `createPlugin` function prior to passing t
 // index.js
 const createPlugin = require('@newrelic/apollo-server-plugin')
 const plugin = createPlugin({
-  captureScalars: false
+  captureScalars: false,
+  captureIntrospectionQueries: true
 })
 
 // imported from supported module
@@ -95,7 +96,8 @@ Configuration may be passed into the `createPlugin` function to override specifi
 
 ```js
 const plugin = createPlugin({
-  captureScalars: true
+  captureScalars: true,
+  captureIntrospectionQueries: false
 })
 ```
 
@@ -105,6 +107,8 @@ const plugin = createPlugin({
   a large number of pre-calculated scalar fields.
 
   **NOTE:** query/mutation resolvers will always be captured even if returning a scalar type.
+
+* `[captureIntrospectionQueries = true]` Enable capture of timings for an [IntrospectionQuery](https://graphql.org/graphql-js/utilities/#introspectionquery).
 
 ### Transactions
 

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -201,10 +201,10 @@ function createPlugin(instrumentationApi, config = {}) {
           let transactionName = '*'
           let segmentName = UNKNOWN_OPERATION
 
-          // if request was for a persistedQuery, the query only lives on
-          // responseContext.source so always use this
+          // if request was for a persistedQuery, the query lives on
+          // responseContext.source
           // see: https://github.com/apollographql/apollo-server/blob/2bccec2c5f5adaaf785f13ab98b6e52e22d5b22e/packages/apollo-server-core/src/requestPipeline.ts#L232
-          let query = responseContext.source
+          let query = responseContext.request.query || responseContext.source
 
           if (query) {
             // attempt to extract arguments to strip from query

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -60,7 +60,9 @@ function createPlugin(instrumentationApi, config = {}) {
   logger.info('Apollo Server plugin created.')
 
   config.captureScalars = config.captureScalars || false
-  config.captureIntrospectionQueries = config.captureIntrospectionQueries === false ? false : true
+  config.captureIntrospectionQueries = config.captureIntrospectionQueries === false
+    ? false
+    : true
 
   logger.debug('Plugin configuration: ', config)
 
@@ -100,18 +102,20 @@ function createPlugin(instrumentationApi, config = {}) {
       return {
         didResolveOperation(resolveContext) {
           if (
-            isIntrospectionQuery(resolveContext.operation, config.captureIntrospectionQueries)
+            isIntrospectionQuery(
+              resolveContext.operation,
+              config.captureIntrospectionQueries
+            )
           ) {
-            logger.trace(`Request is an introspection query and
-            \`config.captureIntrospectionQueries\` is set to \`false\`. Force ignoring the transaction.`)
+            logger.trace('Request is an introspection query and ' +
+            '`config.captureIntrospectionQueries` is set to `false`. ' +
+            'Force ignoring the transaction.')
 
             const transaction = instrumentationApi.tracer.getTransaction()
             if (transaction) {
               transaction.setForceIgnore(true)
             }
-
           }
-
         },
         didEncounterErrors(errorsRequestContext) {
           // Since we don't set the operation segment as active, we want to apply the

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -29,7 +29,7 @@ const OPERATION_TYPE_ATTR = 'graphql.operation.type'
 const OPERATION_NAME_ATTR = 'graphql.operation.name'
 const OPERATION_PATH_ATTR = 'graphql.operation.deepestPath'
 const OPERATION_QUERY_ATTR = 'graphql.operation.query'
-
+const INTROSPECTION_TYPES = ['__schema', '__type']
 const DESTINATIONS = {
   NONE: 0x00
 }
@@ -60,6 +60,7 @@ function createPlugin(instrumentationApi, config = {}) {
   logger.info('Apollo Server plugin created.')
 
   config.captureScalars = config.captureScalars || false
+  config.captureIntrospectionQueries = config.captureIntrospectionQueries === false ? false : true
 
   logger.debug('Plugin configuration: ', config)
 
@@ -97,6 +98,21 @@ function createPlugin(instrumentationApi, config = {}) {
       }
 
       return {
+        didResolveOperation(resolveContext) {
+          if (
+            isIntrospectionQuery(resolveContext.operation, config.captureIntrospectionQueries)
+          ) {
+            logger.trace(`Request is an introspection query and
+            \`config.captureIntrospectionQueries\` is set to \`false\`. Force ignoring the transaction.`)
+
+            const transaction = instrumentationApi.tracer.getTransaction()
+            if (transaction) {
+              transaction.setForceIgnore(true)
+            }
+
+          }
+
+        },
         didEncounterErrors(errorsRequestContext) {
           // Since we don't set the operation segment as active, we want to apply the
           // operation segment as active while setting the error to appropriately assign
@@ -185,10 +201,10 @@ function createPlugin(instrumentationApi, config = {}) {
           let transactionName = '*'
           let segmentName = UNKNOWN_OPERATION
 
-          // if request was for a persistedQuery, the query lives on
-          // responseContext.source
+          // if request was for a persistedQuery, the query only lives on
+          // responseContext.source so always use this
           // see: https://github.com/apollographql/apollo-server/blob/2bccec2c5f5adaaf785f13ab98b6e52e22d5b22e/packages/apollo-server-core/src/requestPipeline.ts#L232
-          let query = responseContext.request.query || responseContext.source
+          let query = responseContext.source
 
           if (query) {
             // attempt to extract arguments to strip from query
@@ -409,6 +425,17 @@ function createModuleUsageMetric(agent) {
   agent.metrics.getOrCreateMetric(
     'Supportability/ExternalModules/ApolloServerPlugin'
   ).incrementCallCount()
+}
+
+function isIntrospectionQuery(operation, captureIntrospectionQueries) {
+  if (captureIntrospectionQueries) {
+    return false
+  }
+
+  return operation.selectionSet.selections.every((selection) => {
+    const fieldName = selection.name.value
+    return INTROSPECTION_TYPES.includes(fieldName)
+  })
 }
 
 module.exports = createPlugin

--- a/tests/integration/config-capture-introspection-queries.test.js
+++ b/tests/integration/config-capture-introspection-queries.test.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { executeQuery } = require('../test-client')
+const { setupEnvConfig } = require('../agent-testing')
+
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
+const TRANSACTION_PREFIX = 'WebTransaction/Expressjs/POST'
+
+const { setupApolloServerTests } = require('../apollo-server-setup')
+const queries = [
+  `{
+    __schema {
+      queryType {
+        fields {
+          name
+        }
+      }
+    }
+  }`,
+  `query introspectionType {
+    __type(name: "Library") {
+      fields {
+        name
+      }
+    }
+  }`
+]
+
+setupApolloServerTests({
+  suiteName: 'default',
+  createTests: createCaptureIntrospectionTests.bind(null, false)
+})
+
+setupApolloServerTests({
+  suiteName: 'captureIntrospectionQueries: true',
+  createTests: createCaptureIntrospectionTests.bind(null, false),
+  pluginConfig: {
+    captureIntrospectionQueries: true
+  }
+})
+
+setupApolloServerTests({
+  suiteName: 'captureIntrospectionQueries: false',
+  createTests: createCaptureIntrospectionTests.bind(null, true),
+  pluginConfig: {
+    captureIntrospectionQueries: false
+  }
+})
+
+
+function createCaptureIntrospectionTests(ignore, t) {
+  setupEnvConfig(t)
+
+  queries.forEach((query) => {
+    t.test(`should ${ignore ? '' : 'not '}ignore transaction when captureIntrospectionQuery is ${!ignore} and query contains introspection types`, (t) => {
+      const { helper, serverUrl } = t.context
+
+
+      helper.agent.on('transactionFinished', (transaction) => {
+        t.equal(transaction.ignore, ignore, `should set transaction.ignore to ${ignore}`)
+      })
+
+      executeQuery(serverUrl, query, (err) => {
+        t.error(err)
+        t.end()
+      })
+    })
+  })
+
+  t.test(`should not ignore transaction when captureIntrospectionQuery is ${!ignore} and query does not contain an introspection type`, (t) => {
+      const { helper, serverUrl } = t.context
+
+
+      helper.agent.on('transactionFinished', (transaction) => {
+        t.notOk(transaction.ignore, 'should set transaction.ignore to false when not an introspection type')
+      })
+
+      const query = `query GetAllForLibrary {
+        library(branch: "downtown") {
+          books {
+            title
+          }
+        }
+      }`
+      executeQuery(serverUrl, query, (err) => {
+        t.error(err)
+        t.end()
+      })
+  })
+}
+

--- a/tests/integration/config-capture-introspection-queries.test.js
+++ b/tests/integration/config-capture-introspection-queries.test.js
@@ -7,11 +7,6 @@
 
 const { executeQuery } = require('../test-client')
 const { setupEnvConfig } = require('../agent-testing')
-
-const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
-const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
-const TRANSACTION_PREFIX = 'WebTransaction/Expressjs/POST'
-
 const { setupApolloServerTests } = require('../apollo-server-setup')
 const queries = [
   `{
@@ -58,12 +53,18 @@ function createCaptureIntrospectionTests(ignore, t) {
   setupEnvConfig(t)
 
   queries.forEach((query) => {
-    t.test(`should ${ignore ? '' : 'not '}ignore transaction when captureIntrospectionQuery is ${!ignore} and query contains introspection types`, (t) => {
+    t.test(`should ${ignore ? '' : 'not '}ignore transaction when
+captureIntrospectionQuery is ${!ignore} and query contains
+introspection types`, (t) => {
       const { helper, serverUrl } = t.context
 
 
       helper.agent.on('transactionFinished', (transaction) => {
-        t.equal(transaction.ignore, ignore, `should set transaction.ignore to ${ignore}`)
+        t.equal(
+          transaction.ignore,
+          ignore,
+          `should set transaction.ignore to ${ignore}`
+        )
       })
 
       executeQuery(serverUrl, query, (err) => {
@@ -73,12 +74,17 @@ function createCaptureIntrospectionTests(ignore, t) {
     })
   })
 
-  t.test(`should not ignore transaction when captureIntrospectionQuery is ${!ignore} and query does not contain an introspection type`, (t) => {
+  t.test(`should not ignore transaction when
+captureIntrospectionQuery is ${!ignore} and query
+does not contain an introspection type`, (t) => {
       const { helper, serverUrl } = t.context
 
 
       helper.agent.on('transactionFinished', (transaction) => {
-        t.notOk(transaction.ignore, 'should set transaction.ignore to false when not an introspection type')
+        t.notOk(
+          transaction.ignore,
+          'should set transaction.ignore to false when not an introspection type'
+        )
       })
 
       const query = `query GetAllForLibrary {


### PR DESCRIPTION
introspection queries

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Provided a new config option to plugin `captureIntrospectionQueries` to ignore transactions for Introspection Queries

## Links
Closes #78 

## Details
GraphQL provides an ability to make introspection queries: [Introspection](https://graphql.org/learn/introspection/). This is not suggested to be enabled in production, [Why you should disable GraphQL Introspection in Production](https://www.apollographql.com/blog/graphql/security/why-you-should-disable-graphql-introspection-in-production/), but in case you still have it on this config option to our plugin will provide a way to ignore these transactions.  

It's also worth noting that GraphQL has more [introspection types](https://github.com/graphql/graphql-js/blob/main/src/type/introspection.ts#L531) but this solution mirrors Apollo Server's suppression of only `__schema` and `__type`, [NoIntrospection validator](https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/ApolloServer.ts#L94)

**Note**: Based on my tests resolvers never fire to get this information so it's probably safe to never short circuit our instrumentation but instead just flag the transaction as ignored.  
