### PR TITLE
always grab query from context.source

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -185,10 +185,9 @@ function createPlugin(instrumentationApi, config = {}) {
           let transactionName = '*'
           let segmentName = UNKNOWN_OPERATION
 
-          // if request was for a persistedQuery, the query lives on
-          // responseContext.source
+          // always use context.source so we can get both queries and persisted queries
           // see: https://github.com/apollographql/apollo-server/blob/2bccec2c5f5adaaf785f13ab98b6e52e22d5b22e/packages/apollo-server-core/src/requestPipeline.ts#L232
-          let query = responseContext.request.query || responseContext.source
+          let query = responseContext.source
 
           if (query) {
             // attempt to extract arguments to strip from query


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated `willSendResponse` hook to always grab the query from context.source

## Links

## Details
In #85 a change was made to support setting the query attribute on segment for persisted queries.  It was discovered providing the or condition was not necessary as the query always lives on `context.source`
