### PR TITLE
set captureIntrospectionQueries default to be false

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To override configuration, invoke the `createPlugin` function prior to passing t
 const createPlugin = require('@newrelic/apollo-server-plugin')
 const plugin = createPlugin({
   captureScalars: false,
-  captureIntrospectionQueries: true
+  captureIntrospectionQueries: false
 })
 
 // imported from supported module
@@ -97,7 +97,7 @@ Configuration may be passed into the `createPlugin` function to override specifi
 ```js
 const plugin = createPlugin({
   captureScalars: true,
-  captureIntrospectionQueries: false
+  captureIntrospectionQueries: true
 })
 ```
 
@@ -108,7 +108,7 @@ const plugin = createPlugin({
 
   **NOTE:** query/mutation resolvers will always be captured even if returning a scalar type.
 
-* `[captureIntrospectionQueries = true]` Enable capture of timings for an [IntrospectionQuery](https://graphql.org/graphql-js/utilities/#introspectionquery).
+* `[captureIntrospectionQueries = false]` Enable capture of timings for an [IntrospectionQuery](https://graphql.org/graphql-js/utilities/#introspectionquery).
 
 ### Transactions
 

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -60,9 +60,7 @@ function createPlugin(instrumentationApi, config = {}) {
   logger.info('Apollo Server plugin created.')
 
   config.captureScalars = config.captureScalars || false
-  config.captureIntrospectionQueries = config.captureIntrospectionQueries === false
-    ? false
-    : true
+  config.captureIntrospectionQueries = config.captureIntrospectionQueries || false
 
   logger.debug('Plugin configuration: ', config)
 

--- a/tests/integration/config-capture-introspection-queries.test.js
+++ b/tests/integration/config-capture-introspection-queries.test.js
@@ -29,7 +29,7 @@ const queries = [
 
 setupApolloServerTests({
   suiteName: 'default',
-  createTests: createCaptureIntrospectionTests.bind(null, false)
+  createTests: createCaptureIntrospectionTests.bind(null, true)
 })
 
 setupApolloServerTests({


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changes the default behavior of plugin to not capture introspection queries(captureIntrospectionQueries now defaults to false)

## Links
Closes #94

## Details
