### PR TITLE
Consistent trans naming

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -94,11 +94,6 @@ function createPlugin(instrumentationApi, config = {}) {
 
       operationSegment.start()
 
-      const deepestResolvedPath = {
-        depth: 0,
-        formatted: null
-      }
-
       return {
         didResolveOperation(resolveContext) {
           if (
@@ -138,11 +133,6 @@ function createPlugin(instrumentationApi, config = {}) {
             willResolveField({args, info}) {
               const pathArray = flattenToArray(info.path)
               const formattedPath = pathArray.reverse().join('.')
-
-              if (pathArray.length > deepestResolvedPath.depth) {
-                deepestResolvedPath.depth = pathArray.length
-                deepestResolvedPath.formatted = formattedPath
-              }
 
               if (!config.captureScalars && !isTopLevelField(info) && isScalar(info)) {
                 return null
@@ -223,8 +213,8 @@ function createPlugin(instrumentationApi, config = {}) {
               query)
           }
 
-          const operationDetails
-            = getOperationDetails(responseContext, deepestResolvedPath.formatted)
+          const operationDetails = getOperationDetails(responseContext)
+          debugger
 
           if (operationDetails) {
             const {operationName, operationType, deepestPath} = operationDetails
@@ -261,22 +251,12 @@ function createPlugin(instrumentationApi, config = {}) {
   }
 }
 
-function getOperationDetails(responseContext, deepestPath) {
-  if (responseContext.operation) {
-    // Resolved operation: parsed and validated, will execute resolvers
-
-    return {
-      operationName: responseContext.operationName,
-      operationType: responseContext.operation.operation,
-      deepestPath: deepestPath
-    }
-  } else if (responseContext.document) {
-    // Failed validation, fallback to document AST
-
-    return getDetailsFromDocument(responseContext.document)
+function getOperationDetails(responseContext) {
+  if (!responseContext.document) {
+    return null
   }
 
-  return null
+  return getDetailsFromDocument(responseContext.document)
 }
 
 function isScalar(fieldInfo) {
@@ -310,7 +290,7 @@ function isTopLevelField(fieldInfo) {
 }
 
 function getDetailsFromDocument(document) {
-  const definition = document.definitions[0]
+  const [ definition ] = document.definitions
 
   const deepestSelectionPath = getDeepestSelectionPath(definition)
   const definitionName = definition.name && definition.name.value

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -214,7 +214,6 @@ function createPlugin(instrumentationApi, config = {}) {
           }
 
           const operationDetails = getOperationDetails(responseContext)
-          debugger
 
           if (operationDetails) {
             const {operationName, operationType, deepestPath} = operationDetails

--- a/tests/versioned/apollo-federation/segments.test.js
+++ b/tests/versioned/apollo-federation/segments.test.js
@@ -54,7 +54,7 @@ function createFederatedSegmentsTests(t, frameworkName) {
       const bookExternal = formatExternalSegment(t.context.bookUrl)
       const magazineExternal = formatExternalSegment(t.context.magazineUrl)
 
-      const operationPart = `query/${ANON_PLACEHOLDER}`
+      const operationPart = `query/${ANON_PLACEHOLDER}/libraries.booksInStock.isbn`
       const expectedSegments = [{
         name: `${TRANSACTION_PREFIX}//${operationPart}`,
         children: [{
@@ -121,9 +121,9 @@ function createFederatedSegmentsTests(t, frameworkName) {
         return
       }
 
-      const operationPart1 = `query/${booksQueryName}`
+      const operationPart1 = `query/${booksQueryName}/libraries.booksInStock.isbn`
       const expectedQuery1Name = `${operationPart1}`
-      const operationPart2 = `query/${magazineQueryName}`
+      const operationPart2 = `query/${magazineQueryName}/libraries.magazinesInStock.issue`
       const expectedQuery2Name = `${operationPart2}`
 
       const batchTransactionPrefix = `${TRANSACTION_PREFIX}//batch`

--- a/tests/versioned/apollo-federation/segments.test.js
+++ b/tests/versioned/apollo-federation/segments.test.js
@@ -12,9 +12,10 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const EXTERNAL_PREFIX = 'External'
 
 const { setupFederatedGatewayServerTests } = require('./federated-gateway-server-setup')
+const { checkResult, shouldSkipTransaction } = require('../common')
 
 setupFederatedGatewayServerTests({
-  suiteName: 'federated egments',
+  suiteName: 'federated segments',
   createTests: createFederatedSegmentsTests
 })
 
@@ -166,34 +167,6 @@ function createFederatedSegmentsTests(t, frameworkName) {
       })
     })
   })
-}
-
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
- function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
-}
-
-/**
- * Sub-graph transactions are flagged as ignore via 'createIgnoreTransactionPlugin'
- * to indicate we are not intending to check data for those in these tests.
- */
-function shouldSkipTransaction(transaction) {
-  if (transaction.forceIgnore) {
-    return true
-  }
-
-  return false
 }
 
 function formatExternalSegment(url) {

--- a/tests/versioned/apollo-federation/transaction-naming.test.js
+++ b/tests/versioned/apollo-federation/transaction-naming.test.js
@@ -10,19 +10,20 @@ const { executeQuery, executeQueryBatch } = require('../../test-client')
 const ANON_PLACEHOLDER = '<anonymous>'
 
 const { setupFederatedGatewayServerTests } = require('./federated-gateway-server-setup')
+const { checkResult, shouldSkipTransaction } = require('../common')
 
 setupFederatedGatewayServerTests({
   suiteName: 'federated transaction names',
-  createTests: createFederatedSegmentsTests
+  createTests: createFederatedTransactionNamingTests
 })
 
 /**
- * Creates a set of standard segment naming and nesting tests to run
+ * Creates a set of standard transaction naming tests to run
  * against express-based apollo-server libraries.
  * It is required that t.context.helper and t.context.serverUrl are set.
  * @param {*} t a tap test instance
  */
-function createFederatedSegmentsTests(t, frameworkName) {
+function createFederatedTransactionNamingTests(t, frameworkName) {
   const TRANSACTION_PREFIX = `WebTransaction/${frameworkName}/POST`
 
   t.test('should properly name transaction when an anonymous federated query', (t) => {
@@ -143,33 +144,5 @@ function createFederatedSegmentsTests(t, frameworkName) {
       })
     })
   })
-}
-
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
- function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
-}
-
-/**
- * Sub-graph transactions are flagged as ignore via 'createIgnoreTransactionPlugin'
- * to indicate we are not intending to check data for those in these tests.
- */
-function shouldSkipTransaction(transaction) {
-  if (transaction.forceIgnore) {
-    return true
-  }
-
-  return false
 }
 

--- a/tests/versioned/apollo-server-fastify/segments.test.js
+++ b/tests/versioned/apollo-server-fastify/segments.test.js
@@ -14,6 +14,7 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
 const { setupApolloServerFastifyTests } = require('./apollo-server-fastify-setup')
+const { checkResult } = require('../common')
 
 setupApolloServerFastifyTests({
   suiteName: 'fastify segments',
@@ -565,18 +566,3 @@ function createFastifySegmentsTests(t, frameworkName) {
   })
 }
 
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
-}

--- a/tests/versioned/apollo-server-hapi/segments.test.js
+++ b/tests/versioned/apollo-server-hapi/segments.test.js
@@ -14,6 +14,7 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
 const { setupApolloServerHapiTests } = require('./apollo-server-hapi-setup')
+const { checkResult } = require('../common')
 
 setupApolloServerHapiTests({
   suiteName: 'hapi segments',
@@ -604,18 +605,3 @@ function createHapiSegmentsTests(t, frameworkName) {
   })
 }
 
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
-}

--- a/tests/versioned/apollo-server-koa/segments.test.js
+++ b/tests/versioned/apollo-server-koa/segments.test.js
@@ -14,6 +14,7 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
 const { setupApolloServerKoaTests } = require('./apollo-server-koa-setup')
+const { checkResult } = require('../common')
 
 setupApolloServerKoaTests({
   suiteName: 'koa segments',
@@ -602,20 +603,4 @@ function createKoaSegmentsTests(t, frameworkName) {
       t.end()
     })
   })
-}
-
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
 }

--- a/tests/versioned/apollo-server-lambda/segments.test.js
+++ b/tests/versioned/apollo-server-lambda/segments.test.js
@@ -15,6 +15,7 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
 const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
+const { checkResult } = require('../common')
 
 setupApolloServerLambdaTests({
   suiteName: 'lambda segments',
@@ -588,18 +589,3 @@ function createLambdaSegmentsTests(t, frameworkName) {
   })
 }
 
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
-}

--- a/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
+++ b/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
@@ -11,6 +11,7 @@ const { executeQueryWithLambdaHandler, executeBatchQueriesWithLambdaHandler }
 const ANON_PLACEHOLDER = '<anonymous>'
 
 const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
+const { checkResult } = require('../common')
 
 setupApolloServerLambdaTests({
   suiteName: 'lambda transaction naming',
@@ -473,18 +474,3 @@ function createTransactionTests(t, frameworkName) {
   })
 }
 
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
-}

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+const common = module.exports
+
+/**
+ * Verify we didn't break anything outright and
+ * test is setup correctly for functioning calls.
+ */
+common.checkResult = function checkResult(t, result, callback) {
+  t.ok(result)
+
+  if (result.errors) {
+    result.errors.forEach((error) => {
+      t.error(error)
+    })
+  }
+
+  setImmediate(callback)
+}
+
+/**
+ * Sub-graph transactions are flagged as ignore via 'createIgnoreTransactionPlugin'
+ * to indicate we are not intending to check data for those in these tests.
+ */
+common.shouldSkipTransaction = function shouldSkipTransaction(transaction) {
+  return !!transaction.forceIgnore
+}

--- a/tests/versioned/express-segments-default-tests.js
+++ b/tests/versioned/express-segments-default-tests.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const { executeQuery, executeQueryBatch } = require('../test-client')
+const { checkResult } = require('./common')
 
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION = '<unknown>'
@@ -629,22 +630,6 @@ function createSegmentsTests(t, frameworkName) {
       t.end()
     })
   })
-}
-
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
 }
 
 module.exports = {

--- a/tests/versioned/express-segments-scalar-tests.js
+++ b/tests/versioned/express-segments-scalar-tests.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const { executeQuery, executeQueryBatch } = require('../test-client')
+const { checkResult } = require('./common')
 
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION = '<unknown>'
@@ -638,22 +639,6 @@ function createSegmentsTests(t, frameworkName) {
       t.end()
     })
   })
-}
-
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
 }
 
 module.exports = {

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -6,6 +6,7 @@
 'use strict'
 
 const { executeQuery, executeQueryBatch } = require('../test-client')
+const { checkResult } = require('./common')
 
 const ANON_PLACEHOLDER = '<anonymous>'
 
@@ -432,22 +433,6 @@ function createTransactionTests(t, frameworkName) {
       t.end()
     })
   })
-}
-
-/**
- * Verify we didn't break anything outright and
- * test is setup correctly for functioning calls.
- */
-function checkResult(t, result, callback) {
-  t.ok(result)
-
-  if (result.errors) {
-    result.errors.forEach((error) => {
-      t.error(error)
-    })
-  }
-
-  setImmediate(callback)
 }
 
 module.exports = {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Always use the GraphQL document schema AST to generate the name and deepest path for transactions for a more consistent naming convention between federated gateway and standard apollo servers

## Links
Closes #86

## Details
