### PR TITLE
added defensive code around items that lack a name property, also add…

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -359,7 +359,11 @@ function getDeepestSelectionPath(definition) {
    */
   function searchSelection(selection, currentParts) {
     const parts = currentParts ? [...currentParts] : []
-    parts.push(selection.name.value)
+
+    // we have found that when queries contain InlineFragments
+    // they lack `name` property, check for property before adding to parts
+    // see https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/84
+    selection.name && parts.push(selection.name.value)
 
     if (selection.selectionSet) {
       selection.selectionSet.selections.forEach((innerSelection) => {

--- a/tests/versioned/apollo-federation/federated-gateway-server-setup.js
+++ b/tests/versioned/apollo-federation/federated-gateway-server-setup.js
@@ -44,11 +44,17 @@ function setupFederatedGatewayServerTests(options, agentConfig) {
       // Do after instrumentation to ensure express isn't loaded too soon.
       const apollo = require('apollo-server')
 
-      // Sub-graph services are currently auto-instrumented via express.
-      // Ignore transaction plugin will prevent creation of standard data and indicate
-      // to tests we do not intend to assert on these transactions.
-      const ignoreTransactionPlugin = createIgnoreTransactionPlugin(nrApi)
-      const subGraphPlugins = [ ignoreTransactionPlugin ]
+      let subGraphPlugins = []
+
+      if (options.instrumentSubGraphs) {
+        subGraphPlugins.push(instrumentationPlugin)
+      } else {
+        // Sub-graph services are currently auto-instrumented via express.
+        // Ignore transaction plugin will prevent creation of standard data and indicate
+        // to tests we do not intend to assert on these transactions.
+        const ignoreTransactionPlugin = createIgnoreTransactionPlugin(nrApi)
+        subGraphPlugins.push(ignoreTransactionPlugin)
+      }
 
       // Services are not instrumented
       const libraryService = await loadLibraries(apollo, subGraphPlugins)

--- a/tests/versioned/apollo-federation/transaction-inline-fragments.test.js
+++ b/tests/versioned/apollo-federation/transaction-inline-fragments.test.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { executeQuery } = require('../../test-client')
+
+const { setupFederatedGatewayServerTests } = require('./federated-gateway-server-setup')
+const { checkResult } = require('../common')
+
+setupFederatedGatewayServerTests({
+  suiteName: 'query with inline fragments',
+  createTests: createFederatedSegmentsTests,
+  instrumentSubGraphs: true
+})
+
+/**
+ * Creates a federated server that instruments all sub graphs and makes a
+ * query that will contain InlineFragments to a subgraph
+ * It is required that t.context.helper and t.context.serverUrl are set.
+ * @param {*} t a tap test instance
+ */
+function createFederatedSegmentsTests(t) {
+  t.test('should nest sub graphs under operation', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const query = `query SubGraphs {
+      libraries {
+        branch
+        booksInStock {
+          isbn,
+          title,
+          author
+        }
+        magazinesInStock {
+          issue,
+          title
+        }
+      }
+    }`
+
+    let transactions = []
+    const expectedTransactions = [
+      'WebTransaction/Expressjs/POST//query/<anonymous>/libraries.branch',
+      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities.booksInStock.isbn',
+      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities.magazinesInStock.issue',
+      'WebTransaction/Expressjs/POST//query/SubGraphs/libraries.booksInStock.isbn'
+    ]
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      transactions.push(transaction.name)
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.equal(transactions.length, 4, 'should create 4 transactions')
+      t.same(expectedTransactions, transactions, 'should properly name each transaction')
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+}

--- a/tests/versioned/apollo-federation/transaction-inline-fragments.test.js
+++ b/tests/versioned/apollo-federation/transaction-inline-fragments.test.js
@@ -26,6 +26,33 @@ function createFederatedSegmentsTests(t) {
   t.test('should nest sub graphs under operation', (t) => {
     const { helper, serverUrl } = t.context
 
+    /**
+     * This query gets deconstructed as such
+     * `{libraries{branch __typename id}}`
+     * `query($representations:[_Any!]!){
+     *    _entities(representations:$representations){
+     *      ...on Library{
+     *        booksInStock{
+     *          isbn title author
+     *        }
+     *      }
+     *    }
+     *  }`
+     * `query($representations:[_Any!]!){
+     *   _entities(representations:$representations){
+     *     ...on Library{
+     *       magazinesInStock{
+     *         issue title
+     *       }
+     *     }
+     *   }
+     * }`
+     * The ones with `...on Library` are [InlineFragments](https://graphql.org/learn/queries/#inline-fragments)
+     * which lack name properites on all the selections within document
+     * without the fix in https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/100
+     * they would crash and not properly name the transactions, also the query request
+     * would fail
+     */
     const query = `query SubGraphs {
       libraries {
         branch


### PR DESCRIPTION
…ed a test to prove this failed before fix

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixes crash when items lack a name property(InlineFragments)

## Links
Closes #84 

## Details
You can verify the fix I made works by reverting the change and running the `tests/versioned/apollo-federation/transaction-inline-fragments.test.js`.  It will fail before the test and pass afterwards
