### PR TITLE
Fix versioned tests with apollo-server 3.0.0 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "unit": "tap --test-regex='(\\/|^tests\\/unit\\/.*\\.test\\.js)$' --no-coverage",
     "versioned": "npm run versioned:npm6",
     "versioned:folder": "versioned-tests --minor -i 2",
-    "versioned:npm6": "versioned-tests --minor -i 2 'tests/versioned/*'",
+    "versioned:npm6": "versioned-tests --minor -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
     "versioned:npm7": "versioned-tests --minor --all -i 2 'tests/versioned/*'"
   },
   "files": [

--- a/tests/versioned/apollo-server-express/apollo-server-express-setup.js
+++ b/tests/versioned/apollo-server-express/apollo-server-express-setup.js
@@ -23,7 +23,7 @@ function setupApolloServerExpressTests({suiteName, createTests, pluginConfig}, c
     let serverUrl = null
     let helper = null
 
-    t.beforeEach(() => {
+    t.beforeEach(async () => {
       // load default instrumentation. express being critical
       helper = utils.TestAgent.makeInstrumented(config)
       const createPlugin = require('../../../lib/create-plugin')
@@ -43,6 +43,7 @@ function setupApolloServerExpressTests({suiteName, createTests, pluginConfig}, c
       })
 
       const app = express()
+      await server.start()
       server.applyMiddleware({ app })
 
       return new Promise((resolve, reject) => {

--- a/tests/versioned/apollo-server-fastify/apollo-server-fastify-setup.js
+++ b/tests/versioned/apollo-server-fastify/apollo-server-fastify-setup.js
@@ -23,7 +23,7 @@ function setupApolloServerFastifyTests({suiteName, createTests, pluginConfig}, c
     let serverUrl = null
     let helper = null
 
-    t.beforeEach(() => {
+    t.beforeEach(async () => {
       // load default instrumentation
       helper = utils.TestAgent.makeInstrumented(config)
       const createPlugin = require('../../../lib/create-plugin')
@@ -42,6 +42,7 @@ function setupApolloServerFastifyTests({suiteName, createTests, pluginConfig}, c
         plugins: [plugin]
       })
 
+      await server.start()
       app.register(server.createHandler())
 
       return new Promise((resolve, reject) => {

--- a/tests/versioned/apollo-server-hapi/apollo-server-hapi-setup.js
+++ b/tests/versioned/apollo-server-hapi/apollo-server-hapi-setup.js
@@ -49,9 +49,8 @@ function setupApolloServerHapiTests({suiteName, createTests, pluginConfig}, conf
         port: 5000
       })
 
+      await server.start()
       await server.applyMiddleware({ app: hapiServer, path: graphqlPath })
-
-      await server.installSubscriptionHandlers(hapiServer.listener)
 
       await hapiServer.start()
 

--- a/tests/versioned/apollo-server-koa/apollo-server-koa-setup.js
+++ b/tests/versioned/apollo-server-koa/apollo-server-koa-setup.js
@@ -24,7 +24,7 @@ function setupApolloServerKoaTests({suiteName, createTests, pluginConfig}, confi
     let serverUrl = null
     let helper = null
 
-    t.beforeEach(() => {
+    t.beforeEach(async () => {
       // load default instrumentation
       helper = utils.TestAgent.makeInstrumented(config)
       const createPlugin = require('../../../lib/create-plugin')
@@ -47,6 +47,7 @@ function setupApolloServerKoaTests({suiteName, createTests, pluginConfig}, confi
         plugins: [plugin]
       })
 
+      await server.start()
       server.applyMiddleware({ app, path: graphqlPath })
 
       return new Promise((resolve, reject) => {

--- a/tests/versioned/apollo-server-lambda/apollo-server-lambda-setup.js
+++ b/tests/versioned/apollo-server-lambda/apollo-server-lambda-setup.js
@@ -33,6 +33,7 @@ function setupApolloServerLambdaTests({suiteName, createTests, pluginConfig}, co
 
     t.beforeEach((t) => {
       const { ApolloServer, gql } = require('apollo-server-lambda')
+      const { version } = require('apollo-server-lambda/package')
 
       helper = utils.TestAgent.makeInstrumented(config)
 
@@ -69,6 +70,7 @@ function setupApolloServerLambdaTests({suiteName, createTests, pluginConfig}, co
 
       patchedHandler = nrApi.setLambdaHandler(handler)
 
+      t.context.modVersion = version
       t.context.helper = helper
       t.context.patchedHandler = patchedHandler
       t.context.stubContext = stubContext

--- a/tests/versioned/apollo-server-lambda/attributes-tests.js
+++ b/tests/versioned/apollo-server-lambda/attributes-tests.js
@@ -25,7 +25,7 @@ setupApolloServerLambdaTests({
 })
 
 function createAttributesTests(t) {
-  t.test('anon query should capture standard attributes except operation name', (t) => {
+  t.test('anon query should capture standard attributes except operation name', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -68,13 +68,11 @@ function createAttributesTests(t) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('named query should capture all standard attributes', (t) => {
+  t.test('named query should capture all standard attributes', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'HeyThere'
@@ -116,13 +114,11 @@ function createAttributesTests(t) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('named query, multi-level, should capture deepest path', (t) => {
+  t.test('named query, multi-level, should capture deepest path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -189,13 +185,11 @@ function createAttributesTests(t) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('named mutation should capture all standard attributes', (t) => {
+  t.test('named mutation should capture all standard attributes', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'AddThing'
@@ -238,13 +232,11 @@ function createAttributesTests(t) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('named mutation should not capture args by default', (t) => {
+  t.test('named mutation should not capture args by default', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'AddThing'
@@ -264,13 +256,11 @@ function createAttributesTests(t) {
       t.notOk(hasAttribute('graphql.field.args.name'))
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('named mutation should capture args when added to include list', (t) => {
+  t.test('named mutation should capture args when added to include list', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     helper.agent.config.attributes.include = ['graphql.field.args.*']
@@ -291,13 +281,11 @@ function createAttributesTests(t) {
       t.matches(resolveAttributes, {'graphql.field.args.name': 'added thing!'})
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('named query should capture args when added to include list', (t) => {
+  t.test('named query should capture args when added to include list', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     helper.agent.config.attributes.include = ['graphql.field.args.*']
@@ -322,13 +310,11 @@ function createAttributesTests(t) {
       t.matches(resolveAttributes, expectedArgAttributes)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('query with variables should capture args when added to include list', (t) => {
+  t.test('query with variables should capture args when added to include list', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     helper.agent.config.attributes.include = ['graphql.field.args.*']
@@ -362,13 +348,11 @@ function createAttributesTests(t) {
       t.matches(resolveAttributes, expectedArgAttributes)
     })
 
-    executeQueryJson(patchedHandler, queryJson, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryJson(patchedHandler, queryJson, stubContext)
+    t.end()
   })
 
-  t.test('should capture query in operation segment attributes', (t) => {
+  t.test('should capture query in operation segment attributes', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'Greetings'
@@ -394,13 +378,11 @@ function createAttributesTests(t) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    t.end()
   })
 
-  t.test('query with args should have args obfuscated in raw query attribute', (t) => {
+  t.test('query with args should have args obfuscated in raw query attribute', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'ParamQueryWithArgs'
@@ -429,9 +411,7 @@ function createAttributesTests(t) {
       t.ok(operationAttributes['graphql.operation.query'].includes('paramQuery(***)'))
     })
 
-    executeQueryJson(patchedHandler, queryJson, stubContext, (err) => {
-      t.error(err)
-      t.end()
-    })
+    await executeQueryJson(patchedHandler, queryJson, stubContext)
+    t.end()
   })
 }

--- a/tests/versioned/apollo-server-lambda/attributes-tests.js
+++ b/tests/versioned/apollo-server-lambda/attributes-tests.js
@@ -5,7 +5,10 @@
 
 'use strict'
 
-const { executeQueryWithLambdaHandler, executeQueryJson } = require('./lambda-test-utils')
+const {
+  executeQueryJson,
+  executeQueryAssertResult
+} = require('./lambda-test-utils')
 const { findSegmentByName } = require('../../agent-testing')
 
 const SEGMENT_DESTINATION = 0x20
@@ -25,8 +28,8 @@ setupApolloServerLambdaTests({
 })
 
 function createAttributesTests(t) {
-  t.test('anon query should capture standard attributes except operation name', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anon query should capture standard attributes except operation name', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       hello
@@ -68,12 +71,17 @@ function createAttributesTests(t) {
       )
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('named query should capture all standard attributes', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query should capture all standard attributes', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'HeyThere'
     const query = `query ${expectedName} {
@@ -114,12 +122,17 @@ function createAttributesTests(t) {
       )
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('named query, multi-level, should capture deepest path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, multi-level, should capture deepest path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBooksByLibrary'
     const query = `query ${expectedName} {
@@ -185,12 +198,17 @@ function createAttributesTests(t) {
       )
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('named mutation should capture all standard attributes', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named mutation should capture all standard attributes', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'AddThing'
     const query = `mutation ${expectedName} {
@@ -232,12 +250,17 @@ function createAttributesTests(t) {
       )
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('named mutation should not capture args by default', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named mutation should not capture args by default', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'AddThing'
     const query = `mutation ${expectedName} {
@@ -256,12 +279,17 @@ function createAttributesTests(t) {
       t.notOk(hasAttribute('graphql.field.args.name'))
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('named mutation should capture args when added to include list', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named mutation should capture args when added to include list', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     helper.agent.config.attributes.include = ['graphql.field.args.*']
     helper.agent.config.emit('attributes.include')
@@ -281,12 +309,17 @@ function createAttributesTests(t) {
       t.matches(resolveAttributes, {'graphql.field.args.name': 'added thing!'})
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('named query should capture args when added to include list', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query should capture args when added to include list', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     helper.agent.config.attributes.include = ['graphql.field.args.*']
     helper.agent.config.emit('attributes.include')
@@ -310,12 +343,17 @@ function createAttributesTests(t) {
       t.matches(resolveAttributes, expectedArgAttributes)
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('query with variables should capture args when added to include list', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('query with variables should capture args when added to include list', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     helper.agent.config.attributes.include = ['graphql.field.args.*']
     helper.agent.config.emit('attributes.include')
@@ -348,12 +386,17 @@ function createAttributesTests(t) {
       t.matches(resolveAttributes, expectedArgAttributes)
     })
 
-    await executeQueryJson(patchedHandler, queryJson, stubContext)
-    t.end()
+    executeQueryJson({
+      handler: patchedHandler,
+      query: queryJson,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('should capture query in operation segment attributes', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('should capture query in operation segment attributes', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'Greetings'
     const query = `query ${expectedName} {
@@ -378,12 +421,17 @@ function createAttributesTests(t) {
       )
     })
 
-    await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
-  t.test('query with args should have args obfuscated in raw query attribute', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('query with args should have args obfuscated in raw query attribute', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'ParamQueryWithArgs'
     const query = `query ${expectedName}($arg1: String!, $arg2: String) {
@@ -411,7 +459,12 @@ function createAttributesTests(t) {
       t.ok(operationAttributes['graphql.operation.query'].includes('paramQuery(***)'))
     })
 
-    await executeQueryJson(patchedHandler, queryJson, stubContext)
-    t.end()
+    executeQueryJson({
+      handler: patchedHandler,
+      query: queryJson,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 }

--- a/tests/versioned/apollo-server-lambda/errors-tests.js
+++ b/tests/versioned/apollo-server-lambda/errors-tests.js
@@ -5,7 +5,9 @@
 
 'use strict'
 
-const { executeQueryWithLambdaHandler } = require('./lambda-test-utils')
+const {
+  executeQueryAssertErrors
+} = require('./lambda-test-utils')
 const agentTesting = require('../../agent-testing')
 
 const ANON_PLACEHOLDER = '<anonymous>'
@@ -18,8 +20,8 @@ const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
 
 
 function createErrorTests(t) {
-  t.test('parsing error should be noticed and assigned to operation span', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('parsing error should be noticed and assigned to operation span', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedErrorMessage = 'Syntax Error: Expected Name, found <EOF>.'
     const expectedErrorType = 'GraphQLError'
@@ -58,25 +60,18 @@ function createErrorTests(t) {
       t.equal(attributes['error.class'], expectedErrorType)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_PARSE_FAILED'
+    })
   })
 
-  t.test('validation error should be noticed and assigned to operation span', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('validation error should be noticed and assigned to operation span', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedErrorMessage = 'Cannot query field "doesnotexist" on type "Book".'
     const expectedErrorType = 'GraphQLError'
@@ -119,25 +114,18 @@ function createErrorTests(t) {
       t.equal(attributes['error.class'], expectedErrorType)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_VALIDATION_FAILED'
+    })
   })
 
-  t.test('resolver error should be noticed and assigned to resolve span', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('resolver error should be noticed and assigned to resolve span', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedErrorMessage = 'Boom goes the dynamite!'
     const expectedErrorType = 'Error'
@@ -172,21 +160,14 @@ function createErrorTests(t) {
       t.equal(attributes['error.class'], expectedErrorType)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'INTERNAL_SERVER_ERROR')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'INTERNAL_SERVER_ERROR'
+    })
   })
 }
 

--- a/tests/versioned/apollo-server-lambda/errors-tests.js
+++ b/tests/versioned/apollo-server-lambda/errors-tests.js
@@ -18,7 +18,7 @@ const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
 
 
 function createErrorTests(t) {
-  t.test('parsing error should be noticed and assigned to operation span', (t) => {
+  t.test('parsing error should be noticed and assigned to operation span', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedErrorMessage = 'Syntax Error: Expected Name, found <EOF>.'
@@ -58,27 +58,24 @@ function createErrorTests(t) {
       t.equal(attributes['error.class'], expectedErrorType)
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [parseError] = jsonResult.errors
-      t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 
-  t.test('validation error should be noticed and assigned to operation span', (t) => {
+  t.test('validation error should be noticed and assigned to operation span', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedErrorMessage = 'Cannot query field "doesnotexist" on type "Book".'
@@ -122,27 +119,24 @@ function createErrorTests(t) {
       t.equal(attributes['error.class'], expectedErrorType)
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [validationError] = jsonResult.errors
-      t.equal(validationError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 
-  t.test('resolver error should be noticed and assigned to resolve span', (t) => {
+  t.test('resolver error should be noticed and assigned to resolve span', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedErrorMessage = 'Boom goes the dynamite!'
@@ -178,24 +172,21 @@ function createErrorTests(t) {
       t.equal(attributes['error.class'], expectedErrorType)
     })
 
-    executeQueryWithLambdaHandler
-      (patchedHandler, invalidQuery, stubContext, (err, result) => {
-        t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-        t.ok(result.body)
+    t.ok(result.body)
 
-        const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-        t.ok(jsonResult)
+    t.ok(jsonResult)
 
-        t.ok(jsonResult.errors)
-        t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-        const [resolverError] = jsonResult.errors
-        t.equal(resolverError.extensions.code, 'INTERNAL_SERVER_ERROR')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'INTERNAL_SERVER_ERROR')
 
-        t.end()
-      })
+    t.end()
   })
 }
 

--- a/tests/versioned/apollo-server-lambda/lambda-test-utils.js
+++ b/tests/versioned/apollo-server-lambda/lambda-test-utils.js
@@ -9,7 +9,7 @@ function executeQueryWithLambdaHandler(handler, query, context, callback) {
   const jsonQuery = JSON.stringify({ query })
   const event = createApiEvent(jsonQuery)
 
-  handler(event, context, callback)
+  return handler(event, context)
 }
 
 function executeBatchQueriesWithLambdaHandler(handler, queries, context, callback) {
@@ -18,7 +18,7 @@ function executeBatchQueriesWithLambdaHandler(handler, queries, context, callbac
   })
   const jsonQuery = JSON.stringify(data)
   const event = createApiEvent(jsonQuery)
-  
+
   handler(event, context, callback)
 }
 

--- a/tests/versioned/apollo-server-lambda/lambda-test-utils.js
+++ b/tests/versioned/apollo-server-lambda/lambda-test-utils.js
@@ -4,31 +4,203 @@
 */
 
 'use strict'
+const { checkResult } = require('../common')
+const utils = module.exports
 
-function executeQueryWithLambdaHandler(handler, query, context) {
+/**
+ * Apollo Server Lambda introduced promise-based handlers
+ * in [2.21.1](https://github.com/apollographql/apollo-server/blob/release-3.0/CHANGELOG.md#v2211)
+ * and in 3.0.0 requires promise-based handlers, this helper
+ * checks and decides which method to execute lambda handler
+ */
+function requiresCallback(version) {
+  return version < '2.21.1'
+}
+
+/**
+ * callback that verifies no error occurred
+ * and result is as expected
+ *
+ * @param {Tap.Test} t
+ * @param {Error} err
+ * @param {*} result of lambda handler
+ */
+function resultCallback(t, err, result) {
+  t.error(err)
+  checkResult(t, result, () => {
+    t.end()
+  })
+}
+
+/**
+ * Executes a lambda handler and asserts no errors occurred
+ * and result is as expected
+ *
+ * @param {Object} params
+ * @param {Function} params.handler to execute
+ * @param {string} params.query to execute
+ * @param {Object} params.context lambda context
+ * @param {string} params.modVersion version of lambda-server-lambda package
+ * @param {Tap.Test} params.t
+ */
+utils.executeQueryAssertResult = async function executeQueryAssertResult({
+  handler,
+  query,
+  context,
+  modVersion,
+  t
+}) {
   const jsonQuery = JSON.stringify({ query })
   const event = createApiEvent(jsonQuery)
 
-  return handler(event, context)
+  if (requiresCallback(modVersion)) {
+    handler(event, context, resultCallback.bind(null, t))
+  } else {
+    const result = await handler(event, context)
+    checkResult(t, result, () => {
+      t.end()
+    })
+  }
 }
 
-function executeBatchQueriesWithLambdaHandler(handler, queries, context) {
+/**
+ * Executes a lambda handler and asserts no errors occurred
+ * Only diff between this and executeQueryAssertResult is the query
+ * contains more than a query string
+ *
+ * @param {Object} params
+ * @param {Function} params.handler to execute
+ * @param {string} params.query to execute
+ * @param {Object} params.context lambda context
+ * @param {string} params.modVersion version of lambda-server-lambda package
+ * @param {Tap.Test} params.t
+ */
+utils.executeQueryJson = async function executeQueryJson({
+  handler,
+  query,
+  context,
+  modVersion,
+  t
+}) {
+  const jsonQuery = JSON.stringify(query)
+  const event = createApiEvent(jsonQuery)
+
+  if (requiresCallback(modVersion)) {
+    handler(event, context, (err) => {
+      t.error(err)
+      t.end()
+    })
+  } else {
+    await handler(event, context)
+    t.end()
+  }
+}
+
+/**
+ * Executes a lambda handler with a batch of queries
+ * and asserts no errors occurred and result is as
+ * expected
+ *
+ * @param {Object} params
+ * @param {Function} params.handler to execute
+ * @param {string} params.queries to execute
+ * @param {Object} params.context lambda context
+ * @param {string} params.modVersion version of lambda-server-lambda package
+ * @param {Tap.Test} params.t
+ */
+utils.executeBatchAssertResult = async function executeBatchAssertResult({
+  handler,
+  queries,
+  context,
+  modVersion,
+  t
+}) {
   const data = queries.map((innerQuery) => {
     return { query: innerQuery }
   })
   const jsonQuery = JSON.stringify(data)
   const event = createApiEvent(jsonQuery)
 
-  return handler(event, context)
+  if (requiresCallback(modVersion)) {
+    handler(event, context, resultCallback.bind(null, t))
+  } else {
+    const result = await handler(event, context)
+    checkResult(t, result, () => {
+      t.end()
+    })
+  }
 }
 
-function executeQueryJson(handler, query, context) {
-  const event = createApiEvent(JSON.stringify(query))
-
-  return handler(event, context)
+/**
+ * A series of assertions used to assert an error
+ * occurred when executing a lambda handler
+ *
+ * @param {*} result of executing lambda handler
+ * @param {string} code to assert in response body
+ * @param {Tap.Test} t
+ */
+function assertErrorBody({ result, code, t }) {
+  t.ok(result.body)
+  const jsonResult = JSON.parse(result.body)
+  t.ok(jsonResult)
+  t.ok(jsonResult.errors)
+  t.equal(jsonResult.errors.length, 1) // should have one parsing error
+  const [parseError] = jsonResult.errors
+  t.equal(parseError.extensions.code, code)
+  t.end()
 }
 
+/**
+ * callback that verifies an error occurred
+ * and error result is as expected
+ *
+ * @param {Tap.Test} t
+ * @param {string} code to assert in response body
+ * @param {Error} err
+ * @param {*} result of lambda handler
+ */
+function errorCallback(t, code, err, result) {
+  t.error(err)
+  assertErrorBody({ result, code, t})
+}
 
+/**
+ * Executes a lambda handler and asserts an error occurred
+ * and result is as expected
+ *
+ * @param {Object} params
+ * @param {Function} params.handler to execute
+ * @param {string} params.query to execute
+ * @param {Object} params.context lambda context
+ * @param {string} params.modVersion version of lambda-server-lambda package
+ * @param {Tap.Test} params.t
+ * @param {string} params.code to assert in response body
+ */
+utils.executeQueryAssertErrors = async function executeQueryAssertErrors({
+  handler,
+  query,
+  context,
+  modVersion,
+  t,
+  code
+}) {
+  const jsonQuery = JSON.stringify({ query })
+  const event = createApiEvent(jsonQuery)
+
+  if (requiresCallback(modVersion)) {
+    handler(event, context, errorCallback.bind(null, t, code))
+  } else {
+    const result = await handler(event, context)
+    assertErrorBody({ result, code, t })
+  }
+}
+
+/**
+ * Creates a formatted API Gateway Proxy event
+ * to be used to execute a lambda handler
+ *
+ * @param {string} query to execute
+ */
 function createApiEvent(query) {
   const apiGatewayProxyEvent = {
     path: '/graphql',
@@ -86,8 +258,3 @@ function createApiEvent(query) {
   return apiGatewayProxyEvent
 }
 
-module.exports = {
-  executeQueryWithLambdaHandler,
-  executeBatchQueriesWithLambdaHandler,
-  executeQueryJson
-}

--- a/tests/versioned/apollo-server-lambda/lambda-test-utils.js
+++ b/tests/versioned/apollo-server-lambda/lambda-test-utils.js
@@ -5,27 +5,27 @@
 
 'use strict'
 
-function executeQueryWithLambdaHandler(handler, query, context, callback) {
+function executeQueryWithLambdaHandler(handler, query, context) {
   const jsonQuery = JSON.stringify({ query })
   const event = createApiEvent(jsonQuery)
 
   return handler(event, context)
 }
 
-function executeBatchQueriesWithLambdaHandler(handler, queries, context, callback) {
+function executeBatchQueriesWithLambdaHandler(handler, queries, context) {
   const data = queries.map((innerQuery) => {
     return { query: innerQuery }
   })
   const jsonQuery = JSON.stringify(data)
   const event = createApiEvent(jsonQuery)
 
-  handler(event, context, callback)
+  return handler(event, context)
 }
 
-function executeQueryJson(handler, query, context, callback) {
+function executeQueryJson(handler, query, context) {
   const event = createApiEvent(JSON.stringify(query))
 
-  handler(event, context, callback)
+  return handler(event, context)
 }
 
 
@@ -36,6 +36,7 @@ function createApiEvent(query) {
       'Accept': 'application/json',
       'Accept-Encoding': 'gzip, deflate, lzma, sdch, br',
       'Accept-Language': 'en-US,en;q=0.8',
+      'Content-Type': 'application/json',
       'CloudFront-Forwarded-Proto': 'https',
       'CloudFront-Is-Desktop-Viewer': 'true',
       'CloudFront-Is-Mobile-Viewer': 'false',

--- a/tests/versioned/apollo-server-lambda/lambda-test-utils.js
+++ b/tests/versioned/apollo-server-lambda/lambda-test-utils.js
@@ -36,7 +36,9 @@ function createApiEvent(query) {
       'Accept': 'application/json',
       'Accept-Encoding': 'gzip, deflate, lzma, sdch, br',
       'Accept-Language': 'en-US,en;q=0.8',
-      'Content-Type': 'application/json',
+      // must be lowercased as this is used in the bodyParser
+      // and assumes the header is lowercased
+      'content-type': 'application/json',
       'CloudFront-Forwarded-Proto': 'https',
       'CloudFront-Is-Desktop-Viewer': 'true',
       'CloudFront-Is-Mobile-Viewer': 'false',

--- a/tests/versioned/apollo-server-lambda/segments.test.js
+++ b/tests/versioned/apollo-server-lambda/segments.test.js
@@ -50,13 +50,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
     })
 
     const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    debugger;
     // TODO: request is failing with 400, invalid post body
     checkResult(t, result, () => {
       t.end()
     })
   })
 
-  t.test('named query, single level', (t) => {
+  t.test('named query, single level', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'HeyThere'
@@ -79,16 +80,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('anonymous query, multi-level', (t) => {
+  t.test('anonymous query, multi-level', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -122,16 +121,13 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
-
-      checkResult(t, result, () => {
-        t.end()
-      })
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, multi-level should return deepest path', (t) => {
+  t.test('named query, multi-level should return deepest path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -167,16 +163,13 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
-
-      checkResult(t, result, () => {
-        t.end()
-      })
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, multi-level, should choose *first* deepest-path', (t) => {
+  t.test('named query, multi-level, should choose *first* deepest-path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -210,16 +203,13 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
-
-      checkResult(t, result, () => {
-        t.end()
-      })
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('anonymous mutation, single level', (t) => {
+  t.test('anonymous mutation, single level', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `mutation {
@@ -247,16 +237,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named mutation, single level, should use mutation name', (t) => {
+  t.test('named mutation, single level, should use mutation name', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'AddThing'
@@ -285,16 +273,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('anonymous query, with params', (t) => {
+  t.test('anonymous query, with params', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -316,16 +302,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, with params', (t) => {
+  t.test('named query, with params', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'BlahQuery'
@@ -348,16 +332,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, with params, multi-level', (t) => {
+  t.test('named query, with params, multi-level', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBookForLibrary'
@@ -401,16 +383,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('batch query should include segments for nested queries', (t) => {
+  t.test('batch query should include segments for nested queries', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName1 = 'GetBookForLibrary'
@@ -480,18 +460,15 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeBatchQueriesWithLambdaHandler
-    (patchedHandler, queries, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeBatchQueriesWithLambdaHandler(patchedHandler, queries, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
   // there will be no document/AST nor resolved operation
-  t.test('when the query cannot be parsed, should have operation placeholder', (t) => {
+  t.test('when the query cannot be parsed, should have operation placeholder', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const invalidQuery = `query {
@@ -516,29 +493,26 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [parseError] = jsonResult.errors
-      t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 
   // if parse succeeds but validation fails, there will not be a resolved operation
   // but the document/AST can still be leveraged for what was intended.
-  t.test('when cannot validate, should include operation segment', (t) => {
+  t.test('when cannot validate, should include operation segment', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const invalidQuery = `query {
@@ -566,24 +540,21 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [parseError] = jsonResult.errors
-      t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 }
 

--- a/tests/versioned/apollo-server-lambda/segments.test.js
+++ b/tests/versioned/apollo-server-lambda/segments.test.js
@@ -5,8 +5,11 @@
 
 'use strict'
 
-const { executeQueryWithLambdaHandler, executeBatchQueriesWithLambdaHandler }
-  = require('./lambda-test-utils')
+const {
+  executeQueryAssertResult,
+  executeBatchAssertResult,
+  executeQueryAssertErrors
+} = require('./lambda-test-utils')
 
 const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION = '<unknown>'
@@ -15,7 +18,6 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
 const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
-const { checkResult } = require('../common')
 
 setupApolloServerLambdaTests({
   suiteName: 'lambda segments',
@@ -28,8 +30,8 @@ setupApolloServerLambdaTests({
 function createLambdaSegmentsTests(t, frameworkName) {
   const TRANSACTION_PREFIX = `WebTransaction/${frameworkName}`
 
-  t.test('anonymous query, single level', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, single level', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       hello
@@ -49,14 +51,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('named query, single level', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, single level', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'HeyThere'
     const query = `query ${expectedName} {
@@ -78,15 +83,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('anonymous query, multi-level', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, multi-level', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       libraries {
@@ -119,14 +126,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('named query, multi-level should return deepest path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, multi-level should return deepest path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBooksByLibrary'
     const query = `query ${expectedName} {
@@ -161,14 +171,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('named query, multi-level, should choose *first* deepest-path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, multi-level, should choose *first* deepest-path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBooksByLibrary'
     const query = `query ${expectedName} {
@@ -201,14 +214,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('anonymous mutation, single level', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous mutation, single level', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `mutation {
       addThing(name: "added thing!")
@@ -235,15 +251,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('named mutation, single level, should use mutation name', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named mutation, single level, should use mutation name', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'AddThing'
     const query = `mutation ${expectedName} {
@@ -271,15 +289,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('anonymous query, with params', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, with params', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       paramQuery(blah: "blah", blee: "blee")
@@ -300,15 +320,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('named query, with params', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, with params', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'BlahQuery'
     const query = `query ${expectedName} {
@@ -330,15 +352,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('named query, with params, multi-level', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, with params, multi-level', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBookForLibrary'
     const query = `query ${expectedName} {
@@ -381,15 +405,17 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
-  t.test('batch query should include segments for nested queries', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('batch query should include segments for nested queries', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName1 = 'GetBookForLibrary'
     const query1 = `query ${expectedName1} {
@@ -458,16 +484,18 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeBatchQueriesWithLambdaHandler(patchedHandler, queries, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeBatchAssertResult({
+      handler: patchedHandler,
+      queries,
+      context: stubContext,
+      t,
+      modVersion
     })
   })
 
   // there will be no document/AST nor resolved operation
-  t.test('when the query cannot be parsed, should have operation placeholder', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('when the query cannot be parsed, should have operation placeholder', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const invalidQuery = `query {
       libraries {
@@ -491,27 +519,20 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_PARSE_FAILED'
+    })
   })
 
   // if parse succeeds but validation fails, there will not be a resolved operation
   // but the document/AST can still be leveraged for what was intended.
-  t.test('when cannot validate, should include operation segment', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('when cannot validate, should include operation segment', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const invalidQuery = `query {
       libraries {
@@ -538,21 +559,14 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_VALIDATION_FAILED'
+    })
   })
 }
 

--- a/tests/versioned/apollo-server-lambda/segments.test.js
+++ b/tests/versioned/apollo-server-lambda/segments.test.js
@@ -50,8 +50,6 @@ function createLambdaSegmentsTests(t, frameworkName) {
     })
 
     const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-    debugger;
-    // TODO: request is failing with 400, invalid post body
     checkResult(t, result, () => {
       t.end()
     })

--- a/tests/versioned/apollo-server-lambda/segments.test.js
+++ b/tests/versioned/apollo-server-lambda/segments.test.js
@@ -28,7 +28,7 @@ setupApolloServerLambdaTests({
 function createLambdaSegmentsTests(t, frameworkName) {
   const TRANSACTION_PREFIX = `WebTransaction/${frameworkName}`
 
-  t.test('anonymous query, single level', (t) => {
+  t.test('anonymous query, single level', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -49,12 +49,10 @@ function createLambdaSegmentsTests(t, frameworkName) {
       t.segments(transaction.trace.root, expectedSegments)
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
-
-      checkResult(t, result, () => {
-        t.end()
-      })
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
+    // TODO: request is failing with 400, invalid post body
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 

--- a/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
+++ b/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
@@ -5,13 +5,15 @@
 
 'use strict'
 
-const { executeQueryWithLambdaHandler, executeBatchQueriesWithLambdaHandler }
-  = require('./lambda-test-utils')
+const {
+  executeBatchAssertResult,
+  executeQueryAssertResult,
+  executeQueryAssertErrors
+} = require('./lambda-test-utils')
 
 const ANON_PLACEHOLDER = '<anonymous>'
 
 const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
-const { checkResult } = require('../common')
 
 setupApolloServerLambdaTests({
   suiteName: 'lambda transaction naming',
@@ -24,8 +26,8 @@ setupApolloServerLambdaTests({
 function createTransactionTests(t, frameworkName) {
   const EXPECTED_PREFIX = `WebTransaction/${frameworkName}`
 
-  t.test('anonymous query, single level, should use anonymous placeholder', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, single level, should use anonymous placeholder', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       hello
@@ -38,15 +40,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('named query, single level, should use query name', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, single level, should use query name', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'HeyThere'
     const query = `query ${expectedName} {
@@ -60,15 +64,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('anonymous query, multi-level should return deepest path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, multi-level should return deepest path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       libraries {
@@ -90,15 +96,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('named query, multi-level should return deepest path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, multi-level should return deepest path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBooksByLibrary'
     const query = `query ${expectedName} {
@@ -121,15 +129,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('named query, multi-level, should choose *first* deepest-path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, multi-level, should choose *first* deepest-path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBooksByLibrary'
     const query = `query ${expectedName} {
@@ -151,15 +161,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('anonymous mutation, single level, should use anonymous placeholder', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous mutation, single level, should use anonymous placeholder', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `mutation {
       addThing(name: "added thing!")
@@ -172,15 +184,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('named mutation, single level, should use mutation name', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named mutation, single level, should use mutation name', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'AddThing'
     const query = `mutation ${expectedName} {
@@ -194,15 +208,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('anonymous query, with params, should use anonymous placeholder', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, with params, should use anonymous placeholder', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const query = `query {
       paramQuery(blah: "blah", blee: "blee")
@@ -215,15 +231,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('named query, with params, should use query name', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, with params, should use query name', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'BlahQuery'
     const query = `query ${expectedName} {
@@ -237,15 +255,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('named query, with params, should return deepest path', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, with params, should return deepest path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'GetBookForLibrary'
     const query = `query ${expectedName} {
@@ -268,15 +288,17 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
-
-    checkResult(t, result, () => {
-      t.end()
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
     })
   })
 
-  t.test('batch query should include "batch" all queries separated by delimeter', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('batch query should include "batch" all queries separated by delimeter', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName1 = 'GetBookForLibrary'
     const query1 = `query ${expectedName1} {
@@ -307,20 +329,23 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeBatchQueriesWithLambdaHandler(patchedHandler, queries, stubContext)
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-    t.equal(jsonResult.length, 2)
-
-    checkResult(t, jsonResult, () => {
-      t.end()
+    executeBatchAssertResult({
+      handler: patchedHandler,
+      queries,
+      context: stubContext,
+      modVersion,
+      t
     })
+    // TODO: should i add to all?
+    // t.ok(result.body)
+
+    // const jsonResult = JSON.parse(result.body)
+    // t.equal(jsonResult.length, 2)
   })
 
   // there will be no document/AST nor resolved operation
-  t.test('if the query cannot be parsed, should be named /*', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('if the query cannot be parsed, should be named /*', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const invalidQuery = `query {
       libraries {
@@ -337,27 +362,20 @@ function createTransactionTests(t, frameworkName) {
       t.equal(transaction.name, `${EXPECTED_PREFIX}//*`)
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_PARSE_FAILED'
+    })
   })
 
   // if parse succeeds but validation fails, there will not be a resolved operation
   // but the document/AST can still be leveraged for what was intended.
-  t.test('anonymous query, when cant validate, should use document/AST', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('anonymous query, when cant validate, should use document/AST', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const invalidQuery = `query {
       libraries {
@@ -379,27 +397,20 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_VALIDATION_FAILED'
+    })
   })
 
   // if parse succeeds but validation fails, there will not be a resolved operation
   // but the document/AST can still be leveraged for what was intended.
-  t.test('named query, when cant validate, should use document/AST', async (t) => {
-    const { helper, patchedHandler, stubContext } = t.context
+  t.test('named query, when cant validate, should use document/AST', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
 
     const expectedName = 'FailsToValidate'
     const invalidQuery = `query ${expectedName} {
@@ -422,21 +433,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
-
-    t.ok(result.body)
-
-    const jsonResult = JSON.parse(result.body)
-
-    t.ok(jsonResult)
-
-    t.ok(jsonResult.errors)
-    t.equal(jsonResult.errors.length, 1) // should have one parsing error
-
-    const [parseError] = jsonResult.errors
-    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
-
-    t.end()
+    executeQueryAssertErrors({
+      handler: patchedHandler,
+      query: invalidQuery,
+      context: stubContext,
+      modVersion,
+      t,
+      code: 'GRAPHQL_VALIDATION_FAILED'
+    })
   })
 }
 

--- a/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
+++ b/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
@@ -24,7 +24,7 @@ setupApolloServerLambdaTests({
 function createTransactionTests(t, frameworkName) {
   const EXPECTED_PREFIX = `WebTransaction/${frameworkName}`
 
-  t.test('anonymous query, single level, should use anonymous placeholder', (t) => {
+  t.test('anonymous query, single level, should use anonymous placeholder', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -38,16 +38,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, single level, should use query name', (t) => {
+  t.test('named query, single level, should use query name', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'HeyThere'
@@ -62,16 +60,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('anonymous query, multi-level should return deepest path', (t) => {
+  t.test('anonymous query, multi-level should return deepest path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -94,16 +90,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, multi-level should return deepest path', (t) => {
+  t.test('named query, multi-level should return deepest path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -127,16 +121,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, multi-level, should choose *first* deepest-path', (t) => {
+  t.test('named query, multi-level, should choose *first* deepest-path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBooksByLibrary'
@@ -159,16 +151,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('anonymous mutation, single level, should use anonymous placeholder', (t) => {
+  t.test('anonymous mutation, single level, should use anonymous placeholder', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `mutation {
@@ -182,16 +172,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named mutation, single level, should use mutation name', (t) => {
+  t.test('named mutation, single level, should use mutation name', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'AddThing'
@@ -206,16 +194,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('anonymous query, with params, should use anonymous placeholder', (t) => {
+  t.test('anonymous query, with params, should use anonymous placeholder', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const query = `query {
@@ -229,16 +215,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, with params, should use query name', (t) => {
+  t.test('named query, with params, should use query name', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'BlahQuery'
@@ -253,16 +237,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('named query, with params, should return deepest path', (t) => {
+  t.test('named query, with params, should return deepest path', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'GetBookForLibrary'
@@ -286,16 +268,14 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler(patchedHandler, query, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, query, stubContext)
 
-      checkResult(t, result, () => {
-        t.end()
-      })
+    checkResult(t, result, () => {
+      t.end()
     })
   })
 
-  t.test('batch query should include "batch" all queries separated by delimeter', (t) => {
+  t.test('batch query should include "batch" all queries separated by delimeter', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName1 = 'GetBookForLibrary'
@@ -327,24 +307,19 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeBatchQueriesWithLambdaHandler
-    (patchedHandler, queries, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeBatchQueriesWithLambdaHandler(patchedHandler, queries, stubContext)
+    t.ok(result.body)
 
-      t.ok(result.body)
+    const jsonResult = JSON.parse(result.body)
+    t.equal(jsonResult.length, 2)
 
-      const jsonResult = JSON.parse(result.body)
-
-      checkResult(t, jsonResult, () => {
-        t.equal(jsonResult.length, 2)
-
-        t.end()
-      })
+    checkResult(t, jsonResult, () => {
+      t.end()
     })
   })
 
   // there will be no document/AST nor resolved operation
-  t.test('if the query cannot be parsed, should be named /*', (t) => {
+  t.test('if the query cannot be parsed, should be named /*', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const invalidQuery = `query {
@@ -362,29 +337,26 @@ function createTransactionTests(t, frameworkName) {
       t.equal(transaction.name, `${EXPECTED_PREFIX}//*`)
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [parseError] = jsonResult.errors
-      t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_PARSE_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 
   // if parse succeeds but validation fails, there will not be a resolved operation
   // but the document/AST can still be leveraged for what was intended.
-  t.test('anonymous query, when cant validate, should use document/AST', (t) => {
+  t.test('anonymous query, when cant validate, should use document/AST', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const invalidQuery = `query {
@@ -407,29 +379,26 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [parseError] = jsonResult.errors
-      t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 
   // if parse succeeds but validation fails, there will not be a resolved operation
   // but the document/AST can still be leveraged for what was intended.
-  t.test('named query, when cant validate, should use document/AST', (t) => {
+  t.test('named query, when cant validate, should use document/AST', async (t) => {
     const { helper, patchedHandler, stubContext } = t.context
 
     const expectedName = 'FailsToValidate'
@@ -453,24 +422,21 @@ function createTransactionTests(t, frameworkName) {
       )
     })
 
-    executeQueryWithLambdaHandler
-    (patchedHandler, invalidQuery, stubContext, (err, result) => {
-      t.error(err)
+    const result = await executeQueryWithLambdaHandler(patchedHandler, invalidQuery, stubContext)
 
-      t.ok(result.body)
+    t.ok(result.body)
 
-      const jsonResult = JSON.parse(result.body)
+    const jsonResult = JSON.parse(result.body)
 
-      t.ok(jsonResult)
+    t.ok(jsonResult)
 
-      t.ok(jsonResult.errors)
-      t.equal(jsonResult.errors.length, 1) // should have one parsing error
+    t.ok(jsonResult.errors)
+    t.equal(jsonResult.errors.length, 1) // should have one parsing error
 
-      const [parseError] = jsonResult.errors
-      t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
+    const [parseError] = jsonResult.errors
+    t.equal(parseError.extensions.code, 'GRAPHQL_VALIDATION_FAILED')
 
-      t.end()
-    })
+    t.end()
   })
 }
 


### PR DESCRIPTION
## Proposed Release Notes
 * Fixed versioned tests to work with 3.0.0 of apollo-server plugins.
 
## Links
Closes #103 

## Additional Context
The koa tests will fail on 3.0.0 because apollo-server-koa removes koa on versioned install.  They moved all frameworks as peer deps and weirdly this one is affected even though all remove the framework from `/test/versions/apollo-server-<framework>/node_modules` folder. I honestly have no idea where it's resolving the framework from.  The only thing I can think of is one of the deps has it nested within itself.  The fix was to apply the `--all` flag when running versioned tests on koa only so it forces installing both `apollo-server-koa` and `koa`.   I only force the `--all` on koa because it is ~5 mins faster per version to run like this:
 * [Only Run Koa with --all](https://github.com/newrelic/newrelic-node-apollo-server-plugin/runs/3059674424?check_suite_focus=true)
 * [Run all packages with --all](https://github.com/newrelic/newrelic-node-apollo-server-plugin/runs/3059774311?check_suite_focus=true)


The largest change in this PR is around apollo-server-lambda tests.  The lambda plugin dropped support for [callbacks in handler](https://github.com/apollographql/apollo-server/blob/release-3.0/CHANGELOG.md#v300-prerelease). I wrote helper wrappers to execute either callback or promise style based on the version of the installed package.  Also, version 3.0.0 uses an express server to execute the lambda functions.  I had to add the `content-type` to the context event so the express body parser would properly parse the buffer that gets created in the [@vendia/serverless-express harness](https://github.com/vendia/serverless-express).  The flow now of a request is this:
```
 JSON in test 
      ---> converts json to utf-8 buffer in @vendia/serverless-express harness 
                ---> express app parsers buffer to JSON and sends to the API Gateway proxy
```
