### PR TITLE
Release v0.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+## 0.3.0 (07/08/2021)
+* Added Apollo Federation support.
+  * Updated to always use the GraphQL document schema AST to generate the name and deepest path for transactions for a more consistent naming convention between federated gateway and standard Apollo servers.
+  * Fixed segment nesting for Apollo Federation gateway operations.
+* Updated `willSendResponse` hook to always grab the query from context.source.
+* Provided a new config option, `captureIntrospectionQueries`, to ignore transactions for Introspection Queries.
+  * `captureIntrospectionQueries` is defaulted to `false`.
+* Added support for capturing persisted queries.
+* Fixed crash when items lack a `name` property (InlineFragments).
+* Added husky + lint staged to run linting on all staged files as a pre-commit git hook.
+* Added `prepare` script to properly bootstrap husky.
+* Upgraded lint-staged to ^11.0.0.
+
 ## 0.2.0 (05/25/2021)
 * Added Node.js v16 to run CI pipeline steps
 * Fixed the main field in package.json to point to proper location

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,6 @@
 * Added support for capturing persisted queries.
 * Fixed crash when items lack a `name` property (InlineFragments).
 * Added husky + lint staged to run linting on all staged files as a pre-commit git hook.
-* Added `prepare` script to properly bootstrap husky.
-* Upgraded lint-staged to ^11.0.0.
 
 ## 0.2.0 (05/25/2021)
 * Added Node.js v16 to run CI pipeline steps

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -327,7 +327,7 @@ SOFTWARE.
 
 ### lint-staged
 
-This product includes source derived from [lint-staged](https://github.com/okonet/lint-staged) ([v10.5.4](https://github.com/okonet/lint-staged/tree/v10.5.4)), distributed under the [MIT License](https://github.com/okonet/lint-staged/blob/v10.5.4/LICENSE):
+This product includes source derived from [lint-staged](https://github.com/okonet/lint-staged) ([v11.0.0](https://github.com/okonet/lint-staged/tree/v11.0.0)), distributed under the [MIT License](https://github.com/okonet/lint-staged/blob/v11.0.0/LICENSE):
 
 ```
 The MIT License (MIT)

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue May 25 2021 14:35:53 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu Jul 08 2021 14:29:16 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeDev": true,
@@ -57,15 +57,15 @@
       "publisher": "Typicode",
       "email": "typicode@gmail.com"
     },
-    "lint-staged@10.5.4": {
+    "lint-staged@11.0.0": {
       "name": "lint-staged",
-      "version": "10.5.4",
-      "range": "^10.5.4",
+      "version": "11.0.0",
+      "range": "^11.0.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/okonet/lint-staged",
-      "versionedRepoUrl": "https://github.com/okonet/lint-staged/tree/v10.5.4",
+      "versionedRepoUrl": "https://github.com/okonet/lint-staged/tree/v11.0.0",
       "licenseFile": "node_modules/lint-staged/LICENSE",
-      "licenseUrl": "https://github.com/okonet/lint-staged/blob/v10.5.4/LICENSE",
+      "licenseUrl": "https://github.com/okonet/lint-staged/blob/v11.0.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"


### PR DESCRIPTION
* Added Apollo Federation support.
  * Updated to always use the GraphQL document schema AST to generate the name and deepest path for transactions for a more consistent naming convention between federated gateway and standard Apollo servers.
  * Fixed segment nesting for Apollo Federation gateway operations.
* Updated `willSendResponse` hook to always grab the query from context.source.
* Provided a new config option, `captureIntrospectionQueries`, to ignore transactions for Introspection Queries.
  * `captureIntrospectionQueries` is defaulted to `false`.
* Added support for capturing persisted queries.
* Fixed crash when items lack a `name` property (InlineFragments).
* Added husky + lint staged to run linting on all staged files as a pre-commit git hook.

## Links
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/85
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/89
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/90
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/91
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/92
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/95
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/96
https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/97