### PR TITLE
Ignore health check and service definition queries received from Federated servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Configuration may be passed into the `createPlugin` function to override specifi
 ```js
 const plugin = createPlugin({
   captureScalars: true,
-  captureIntrospectionQueries: true
+  captureIntrospectionQueries: true,
+  captureServiceDefinitionQuery: true,
+  captureHealthCheckQuery: true
 })
 ```
 
@@ -109,6 +111,10 @@ const plugin = createPlugin({
   **NOTE:** query/mutation resolvers will always be captured even if returning a scalar type.
 
 * `[captureIntrospectionQueries = false]` Enable capture of timings for an [IntrospectionQuery](https://graphql.org/graphql-js/utilities/#introspectionquery).
+
+* `[captureServiceDefinitionQuery = false]` Enable capture of timings for a [Service Definition query](https://www.apollographql.com/docs/federation/federation-spec/#fetch-service-capabilities) received from an Apollo Federated Gateway Server.
+
+* `[captureHealthCheckQuery = false]` Enable capture of timings for a [Health Check query](https://graphql.org/graphql-js/utilities/#introspectionquery) received from an Apollo Federated Gateway Server.
 
 ### Apollo Federation Support
 

--- a/README.md
+++ b/README.md
@@ -43,21 +43,6 @@ const server = new ApolloServer({
 })
 ```
 
-To override configuration, invoke the `createPlugin` function prior to passing to Apollo Server:
-
-```js
-// index.js
-const createPlugin = require('@newrelic/apollo-server-plugin')
-const plugin = createPlugin()
-
-// imported from supported module
-const server = new ApolloServer({
-  typeDefs,
-  resolvers,
-  plugins: [plugin]
-})
-```
-
 ## Usage
 
 The New Relic plugin is known to work with the following Apollo Server modules:
@@ -89,7 +74,7 @@ const server = new ApolloServer({
 ```
 ### Configuration
 
-Configuration may be passed into the `createPlugin` function to override specific values. The configuration object and all properties are optional.
+Configuration may be passed into the `createPlugin` function to override specific values. To override configuration, invoke the `createPlugin` function prior to passing to Apollo Server. The configuration object and all properties are optional.
 
 ```js
 const plugin = createPlugin({

--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ To override configuration, invoke the `createPlugin` function prior to passing t
 ```js
 // index.js
 const createPlugin = require('@newrelic/apollo-server-plugin')
-const plugin = createPlugin({
-  captureScalars: false,
-  captureIntrospectionQueries: false
-})
+const plugin = createPlugin()
 
 // imported from supported module
 const server = new ApolloServer({
@@ -114,7 +111,7 @@ const plugin = createPlugin({
 
 * `[captureServiceDefinitionQuery = false]` Enable capture of timings for a [Service Definition query](https://www.apollographql.com/docs/federation/federation-spec/#fetch-service-capabilities) received from an Apollo Federated Gateway Server.
 
-* `[captureHealthCheckQuery = false]` Enable capture of timings for a [Health Check query](https://graphql.org/graphql-js/utilities/#introspectionquery) received from an Apollo Federated Gateway Server.
+* `[captureHealthCheckQuery = false]` Enable capture of timings for a [Health Check query](https://www.apollographql.com/docs/federation/api/apollo-gateway/#servicehealthcheck) received from an Apollo Federated Gateway Server.
 
 ### Apollo Federation Support
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Configuration may be passed into the `createPlugin` function to override specifi
 const plugin = createPlugin({
   captureScalars: true,
   captureIntrospectionQueries: true,
-  captureServiceDefinitionQuery: true,
-  captureHealthCheckQuery: true
+  captureServiceDefinitionQueries: true,
+  captureHealthCheckQueries: true
 })
 ```
 
@@ -109,9 +109,9 @@ const plugin = createPlugin({
 
 * `[captureIntrospectionQueries = false]` Enable capture of timings for an [IntrospectionQuery](https://graphql.org/graphql-js/utilities/#introspectionquery).
 
-* `[captureServiceDefinitionQuery = false]` Enable capture of timings for a [Service Definition query](https://www.apollographql.com/docs/federation/federation-spec/#fetch-service-capabilities) received from an Apollo Federated Gateway Server.
+* `[captureServiceDefinitionQueries = false]` Enable capture of timings for a [Service Definition query](https://www.apollographql.com/docs/federation/federation-spec/#fetch-service-capabilities) received from an Apollo Federated Gateway Server.
 
-* `[captureHealthCheckQuery = false]` Enable capture of timings for a [Health Check query](https://www.apollographql.com/docs/federation/api/apollo-gateway/#servicehealthcheck) received from an Apollo Federated Gateway Server.
+* `[captureHealthCheckQueries = false]` Enable capture of timings for a [Health Check query](https://www.apollographql.com/docs/federation/api/apollo-gateway/#servicehealthcheck) received from an Apollo Federated Gateway Server.
 
 ### Apollo Federation Support
 

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -357,7 +357,9 @@ function getDeepestUniqueSelection(definition) {
     })
 
     if (filtered.length > 1 || filtered.length === 0) {
-      break // selections not unique
+      // selections not unique OR
+      // only one IGNORED_PATH_FIELDS item in selections
+      break
     }
 
     selection = filtered[0]

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -356,7 +356,7 @@ function getDeepestUniqueSelection(definition) {
       return IGNORED_PATH_FIELDS.indexOf(currentSelection.name.value) < 0
     })
 
-    if (filtered.length > 1) {
+    if (filtered.length > 1 || filtered.length === 0) {
       break // selections not unique
     }
 
@@ -428,10 +428,7 @@ function isHealthCheckQuery(operation) {
 function shouldIgnoreTransaction(operation, config, logger) {
   if (
     !config.captureIntrospectionQueries &&
-    isIntrospectionQuery(
-      operation,
-      config.captureIntrospectionQueries
-    )
+    isIntrospectionQuery(operation)
   ) {
     logger.trace('Request is an introspection query and ' +
     '`config.captureIntrospectionQueries` is set to `false`. ' +
@@ -442,10 +439,7 @@ function shouldIgnoreTransaction(operation, config, logger) {
 
   if (
     !config.captureServiceDefinitionQueries &&
-    isServiceDefinitionQuery(
-      operation,
-      config.captureServiceDefinitionQueries
-    )
+    isServiceDefinitionQuery(operation)
   ) {
     logger.trace('Request is an Apollo Federated Gateway service definition query and ' +
     '`config.captureServiceDefinitionQueries` is set to `false`. ' +
@@ -456,10 +450,7 @@ function shouldIgnoreTransaction(operation, config, logger) {
 
   if (
     !config.captureHealthCheckQueries &&
-    isHealthCheckQuery(
-      operation,
-      config.captureHealthCheckQueries
-    )
+    isHealthCheckQuery(operation)
   ) {
     logger.trace('Request is an Apollo Federated Gateway health check query and ' +
     '`config.captureHealthCheckQueries` is set to `false`. ' +

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -63,6 +63,8 @@ function createPlugin(instrumentationApi, config = {}) {
 
   config.captureScalars = config.captureScalars || false
   config.captureIntrospectionQueries = config.captureIntrospectionQueries || false
+  config.captureServiceDefinitionQueries = config.captureServiceDefinitionQueries || false
+  config.captureHealthCheckQueries = config.captureHealthCheckQueries || false
 
   logger.debug('Plugin configuration: ', config)
 
@@ -409,35 +411,24 @@ function createModuleUsageMetric(agent) {
   ).incrementCallCount()
 }
 
-function isIntrospectionQuery(operation, captureIntrospectionQueries) {
-  if (captureIntrospectionQueries) {
-    return false
-  }
-
+function isIntrospectionQuery(operation) {
   return operation.selectionSet.selections.every((selection) => {
     const fieldName = selection.name.value
     return INTROSPECTION_TYPES.includes(fieldName)
   })
 }
 
-function isServiceDefinitionQuery(operation, captureServiceDefinitionQuery) {
-  if (captureServiceDefinitionQuery) {
-    return false
-  }
-
+function isServiceDefinitionQuery(operation) {
   return operation.name && operation.name.value === SERVICE_DEFINITION_QUERY_NAME
 }
 
-function isHealthCheckQuery(operation, captureHealthCheckQuery) {
-  if (captureHealthCheckQuery) {
-    return false
-  }
-
+function isHealthCheckQuery(operation) {
   return operation.name && operation.name.value === HEALTH_CHECK_QUERY_NAME
 }
 
 function shouldIgnoreTransaction(operation, config, logger) {
   if (
+    !config.captureIntrospectionQueries &&
     isIntrospectionQuery(
       operation,
       config.captureIntrospectionQueries
@@ -451,26 +442,28 @@ function shouldIgnoreTransaction(operation, config, logger) {
   }
 
   if (
+    !config.captureServiceDefinitionQueries &&
     isServiceDefinitionQuery(
       operation,
-      config.captureServiceDefinitionQuery
+      config.captureServiceDefinitionQueries
     )
   ) {
-    logger.trace('Request is a ApolloGetServiceDefinition query and ' +
-    '`config.captureServiceDefinitionQuery` is set to `false`. ' +
+    logger.trace('Request is an Apollo Federated Gateway service definition query and ' +
+    '`config.captureServiceDefinitionQueries` is set to `false`. ' +
     'Force ignoring the transaction.')
 
     return true
   }
 
   if (
+    !config.captureHealthCheckQueries &&
     isHealthCheckQuery(
       operation,
-      config.captureHealthCheckQuery
+      config.captureHealthCheckQueries
     )
   ) {
-    logger.trace('Request is a ApolloGetServiceDefinition query and ' +
-    '`config.captureHealthCheckQuery` is set to `false`. ' +
+    logger.trace('Request is an Apollo Federated Gateway health check query and ' +
+    '`config.captureHealthCheckQueries` is set to `false`. ' +
     'Force ignoring the transaction.')
 
     return true

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -30,6 +30,8 @@ const OPERATION_NAME_ATTR = 'graphql.operation.name'
 const OPERATION_PATH_ATTR = 'graphql.operation.deepestPath'
 const OPERATION_QUERY_ATTR = 'graphql.operation.query'
 const INTROSPECTION_TYPES = ['__schema', '__type']
+const SERVICE_DEFINITION_QUERY_NAME = '__ApolloGetServiceDefinition__'
+const HEALTH_CHECK_QUERY_NAME = '__ApolloServiceHealthCheck__'
 const DESTINATIONS = {
   NONE: 0x00
 }
@@ -94,16 +96,7 @@ function createPlugin(instrumentationApi, config = {}) {
 
       return {
         didResolveOperation(resolveContext) {
-          if (
-            isIntrospectionQuery(
-              resolveContext.operation,
-              config.captureIntrospectionQueries
-            )
-          ) {
-            logger.trace('Request is an introspection query and ' +
-            '`config.captureIntrospectionQueries` is set to `false`. ' +
-            'Force ignoring the transaction.')
-
+          if (shouldIgnoreTransaction(resolveContext.operation, config, logger)) {
             const transaction = instrumentationApi.tracer.getTransaction()
             if (transaction) {
               transaction.setForceIgnore(true)
@@ -425,6 +418,65 @@ function isIntrospectionQuery(operation, captureIntrospectionQueries) {
     const fieldName = selection.name.value
     return INTROSPECTION_TYPES.includes(fieldName)
   })
+}
+
+function isServiceDefinitionQuery(operation, captureServiceDefinitionQuery) {
+  if (captureServiceDefinitionQuery) {
+    return false
+  }
+
+  return operation.name && operation.name.value === SERVICE_DEFINITION_QUERY_NAME
+}
+
+function isHealthCheckQuery(operation, captureHealthCheckQuery) {
+  if (captureHealthCheckQuery) {
+    return false
+  }
+
+  return operation.name && operation.name.value === HEALTH_CHECK_QUERY_NAME
+}
+
+function shouldIgnoreTransaction(operation, config, logger) {
+  if (
+    isIntrospectionQuery(
+      operation,
+      config.captureIntrospectionQueries
+    )
+  ) {
+    logger.trace('Request is an introspection query and ' +
+    '`config.captureIntrospectionQueries` is set to `false`. ' +
+    'Force ignoring the transaction.')
+
+    return true
+  }
+
+  if (
+    isServiceDefinitionQuery(
+      operation,
+      config.captureServiceDefinitionQuery
+    )
+  ) {
+    logger.trace('Request is a ApolloGetServiceDefinition query and ' +
+    '`config.captureServiceDefinitionQuery` is set to `false`. ' +
+    'Force ignoring the transaction.')
+
+    return true
+  }
+
+  if (
+    isHealthCheckQuery(
+      operation,
+      config.captureHealthCheckQuery
+    )
+  ) {
+    logger.trace('Request is a ApolloGetServiceDefinition query and ' +
+    '`config.captureHealthCheckQuery` is set to `false`. ' +
+    'Force ignoring the transaction.')
+
+    return true
+  }
+
+  return false
 }
 
 module.exports = createPlugin

--- a/tests/versioned/apollo-federation/federated-gateway-server-setup.js
+++ b/tests/versioned/apollo-federation/federated-gateway-server-setup.js
@@ -130,7 +130,7 @@ async function loadGateway({ ApolloServer }, services, plugins) {
   // eslint-disable-next-line no-console
   console.log(`${name} ready at ${url}`)
 
-  return { name, url, server }
+  return { name, url, server, gateway }
 }
 
 async function loadLibraries({ ApolloServer, gql }, plugins) {
@@ -196,5 +196,7 @@ function initializePlugins(instrumentationApi, plugins) {
 }
 
 module.exports = {
-  setupFederatedGatewayServerTests
+  setupFederatedGatewayServerTests,
+  loadLibraries,
+  loadGateway
 }

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -13,7 +13,8 @@
         "apollo-server": ">=2.25.1 <3.0.0"
       },
       "files": [
-        "segments.test.js"
+        "segments.test.js",
+        "service-definition-and-healthcheck-filtering.test.js"
       ]
     },
     {

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -27,7 +27,8 @@
         "apollo-server": "2.25.1"
       },
       "files": [
-        "segments.test.js"
+        "segments.test.js",
+        "service-definition-and-healthcheck-filtering.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
+++ b/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
@@ -29,7 +29,7 @@ tap.test('Capture/Ignore Service Definition and Health Check ' +
     agentConfig = null
   })
 
-  t.test('Should not ignore Service Definiion query by default', async (t) => {
+  t.test('Should ignore Service Definiion query by default', async (t) => {
     // load default instrumentation. express being critical
     helper = utils.TestAgent.makeInstrumented(agentConfig)
     let ignore = true
@@ -68,7 +68,7 @@ tap.test('Capture/Ignore Service Definition and Health Check ' +
   })
 
   t.test('Should not ignore Service Definition query ' +
-    'when captureServiceDefinitionQuery set to true', async (t) => {
+    'when captureServiceDefinitionQueries set to true', async (t) => {
     // load default instrumentation. express being critical
     helper = utils.TestAgent.makeInstrumented(agentConfig)
     let ignore = false
@@ -82,7 +82,7 @@ tap.test('Capture/Ignore Service Definition and Health Check ' +
     })
 
     const pluginConfig = {
-      captureServiceDefinitionQuery: true
+      captureServiceDefinitionQueries: true
     }
 
     const nrApi = helper.getAgentApi()
@@ -152,7 +152,7 @@ tap.test('Capture/Ignore Service Definition and Health Check ' +
   })
 
   t.test('Should not ignore Health Check query when ' +
-    'captureHealthCheckQuery set to true', async (t) => {
+    'captureHealthCheckQueries set to true', async (t) => {
     // load default instrumentation. express being critical
     helper = utils.TestAgent.makeInstrumented(agentConfig)
     let ignore = false
@@ -168,7 +168,7 @@ tap.test('Capture/Ignore Service Definition and Health Check ' +
     })
 
     const pluginConfig = {
-      captureHealthCheckQuery: true
+      captureHealthCheckQueries: true
     }
 
     const nrApi = helper.getAgentApi()

--- a/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
+++ b/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const tap = require('tap')
+const utils = require('@newrelic/test-utilities')
+const createPlugin = require('../../../lib/create-plugin')
+
+const { loadLibraries, loadGateway } = require('./federated-gateway-server-setup')
+
+tap.test('Capture/Ignore Service Definition and Health Check ' +
+  'query transaction from sub-graph servers', (t) => {
+  t.autoend()
+
+  let gatewayServer = null
+  let libraryServer = null
+  let helper = null
+  let agentConfig = null
+
+  t.afterEach(() => {
+    helper.unload()
+
+    gatewayServer = null
+    libraryServer = null
+    helper = null
+    agentConfig = null
+  })
+
+  t.test('Should not ignore Service Definiion query by default', async (t) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented(agentConfig)
+    let ignore = true
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.ignore,
+        ignore,
+        `should set transaction.ignore to ${ignore}`
+      )
+    })
+
+    const pluginConfig = {}
+
+    const nrApi = helper.getAgentApi()
+
+    const instrumentationPlugin = createPlugin(nrApi.shim, pluginConfig)
+    const plugins = [instrumentationPlugin]
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const apollo = require('apollo-server')
+
+    const libraryService = await loadLibraries(apollo, plugins)
+    libraryServer = libraryService.server
+
+    const services = [
+      { name: libraryService.name, url: libraryService.url }
+    ]
+
+    const gatewayService = await loadGateway(apollo, services, plugins)
+
+    gatewayServer = gatewayService.server
+
+    gatewayServer.stop()
+    libraryServer.stop()
+  })
+
+  t.test('Should not ignore Service Definition query ' +
+    'when captureServiceDefinitionQuery set to true', async (t) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented(agentConfig)
+    let ignore = false
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.ignore,
+        ignore,
+        `should set transaction.ignore to ${ignore}`
+      )
+    })
+
+    const pluginConfig = {
+      captureServiceDefinitionQuery: true
+    }
+
+    const nrApi = helper.getAgentApi()
+
+    const instrumentationPlugin = createPlugin(nrApi.shim, pluginConfig)
+    const plugins = [instrumentationPlugin]
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const apollo = require('apollo-server')
+
+    const libraryService = await loadLibraries(apollo, plugins)
+    libraryServer = libraryService.server
+
+    const services = [
+      { name: libraryService.name, url: libraryService.url }
+    ]
+
+    const gatewayService = await loadGateway(apollo, services, plugins)
+
+    gatewayServer = gatewayService.server
+
+    gatewayServer.stop()
+    libraryServer.stop()
+  })
+
+  t.test('Should ignore Health Check query by default', async (t) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented(agentConfig)
+    let ignore = true
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      if (transaction.name.includes('__ApolloServiceHealthCheck__')) {
+        t.equal(
+          transaction.ignore,
+          ignore,
+          `should set transaction.ignore to ${ignore}`
+        )
+      }
+    })
+
+    const pluginConfig = {}
+
+    const nrApi = helper.getAgentApi()
+
+    const instrumentationPlugin = createPlugin(nrApi.shim, pluginConfig)
+    const plugins = [instrumentationPlugin]
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const apollo = require('apollo-server')
+
+    const libraryService = await loadLibraries(apollo, plugins)
+    libraryServer = libraryService.server
+
+    const services = [
+      { name: libraryService.name, url: libraryService.url }
+    ]
+
+    const gatewayService = await loadGateway(apollo, services, plugins)
+
+    // trigger the healthcheck
+    await gatewayService.gateway.serviceHealthCheck()
+
+    gatewayServer = gatewayService.server
+
+    gatewayServer.stop()
+    libraryServer.stop()
+  })
+
+  t.test('Should not ignore Health Check query when ' +
+    'captureHealthCheckQuery set to true', async (t) => {
+    // load default instrumentation. express being critical
+    helper = utils.TestAgent.makeInstrumented(agentConfig)
+    let ignore = false
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      if (transaction.name.includes('__ApolloServiceHealthCheck__')) {
+        t.equal(
+          transaction.ignore,
+          ignore,
+          `should set transaction.ignore to ${ignore}`
+        )
+      }
+    })
+
+    const pluginConfig = {
+      captureHealthCheckQuery: true
+    }
+
+    const nrApi = helper.getAgentApi()
+
+    const instrumentationPlugin = createPlugin(nrApi.shim, pluginConfig)
+    const plugins = [instrumentationPlugin]
+
+    // Do after instrumentation to ensure express isn't loaded too soon.
+    const apollo = require('apollo-server')
+
+    const libraryService = await loadLibraries(apollo, plugins)
+    libraryServer = libraryService.server
+
+    const services = [
+      { name: libraryService.name, url: libraryService.url }
+    ]
+
+    const gatewayService = await loadGateway(apollo, services, plugins)
+
+    // trigger the healthcheck
+    await gatewayService.gateway.serviceHealthCheck()
+
+    gatewayServer = gatewayService.server
+
+    gatewayServer.stop()
+    libraryServer.stop()
+  })
+})

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -64,6 +64,28 @@ function createTransactionTests(t, frameworkName) {
     })
   })
 
+  t.test('Federated Server health check query with only __typename ' +
+    'in selection set should omit deepest unique path', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = '__ApolloServiceHealthCheck__'
+    const query = `query ${expectedName} { __typename }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}`
+      )
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
   t.test('anonymous query, multi-level should return deepest unique path', (t) => {
     const { helper, serverUrl } = t.context
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Updated plugin to Ignore Service Definition and/or Health Check queries received from Federated Gateway Server.
  Setting config item(s) `captureServiceDefinitionQuery` and/or `captureHealthCheckQuery` to true will enable plugin to capture timings for those respective queries.
## Links
Closes: #110 
## Details
