### PR TITLE
removed pinning versioned tests to <3.0.0

### DIFF
--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/federation": ">=0.25.2",
         "@apollo/gateway": ">=0.25.2 <0.31.0",
-        "apollo-server": ">=2.25.1 <3.0.0"
+        "apollo-server": ">=2.25.1"
       },
       "files": [
         "segments.test.js"

--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-express": ">=2.14.0 <3.0.0",
+        "apollo-server-express": ">=2.14.0",
         "express": "4.17.1"
       },
       "files": [

--- a/tests/versioned/apollo-server-fastify/package.json
+++ b/tests/versioned/apollo-server-fastify/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-fastify": ">=2.14.0 <3.0.0",
+        "apollo-server-fastify": ">=2.14.0",
         "fastify": "3.5.0"
       },
       "files": [

--- a/tests/versioned/apollo-server-fastify/package.json
+++ b/tests/versioned/apollo-server-fastify/package.json
@@ -9,7 +9,7 @@
       },
       "dependencies": {
         "apollo-server-fastify": ">=2.14.0",
-        "fastify": "3.5.0"
+        "fastify": "3.17.0"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-server-hapi/package.json
+++ b/tests/versioned/apollo-server-hapi/package.json
@@ -8,7 +8,7 @@
         "node": ">=12 <16"
       },
       "dependencies": {
-        "apollo-server-hapi": ">=2.14.0 <3.0.0",
+        "apollo-server-hapi": ">=2.14.0",
         "@hapi/hapi": "18.4.1"
       },
       "files": [

--- a/tests/versioned/apollo-server-koa/package.json
+++ b/tests/versioned/apollo-server-koa/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-koa": ">=2.14.0 <3.0.0",
+        "apollo-server-koa": ">=2.14.0",
         "koa": ">=2.13.0"
       },
       "files": [

--- a/tests/versioned/apollo-server-lambda/package.json
+++ b/tests/versioned/apollo-server-lambda/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-lambda": ">=2.14.0 <3.0.0"
+        "apollo-server-lambda": ">=2.14.0"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -8,7 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server": ">=2.14.0 <3.0.0"
+        "apollo-server": ">=2.14.0"
       },
       "files": [
         "transaction-naming.test.js",


### PR DESCRIPTION
## Details
When I did https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/106 I started branch before we pinned the tests to `<3.0.0` and never rebased to fix.  Locally I was testing on all versioned but I guess in CI when it merged main it was still pinned.  This removes the pinning for realz
