### PR TITLE
Fix hapi versioned tests

### DIFF
--- a/tests/versioned/apollo-server-hapi/package.json
+++ b/tests/versioned/apollo-server-hapi/package.json
@@ -17,6 +17,21 @@
         "errors.test.js",
         "attributes.test.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=16"
+      },
+      "dependencies": {
+        "apollo-server-hapi": ">=3.0.0",
+        "@hapi/hapi": "^20.1.2"
+      },
+      "files": [
+        "segments.test.js",
+        "transaction-naming.test.js",
+        "errors.test.js",
+        "attributes.test.js"
+      ]
     }
   ],
   "dependencies": {}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added running `apollo-sever-hapi` versioned tests on node 16, `apollo-server-hapi@3.0.0`, `@hapi/hapi@20.1.x`

## Links
Closes #81 

## Details
`apollo-server-hapi@3.0.0` requires at least `@hapi/hapi@20.1.2` as it is a peer dep and npm 7 enforces this and will not install the library if it cannot resolve the semver range. 

I also branched off of this PR https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/114, so I will have to rebase once the other is merged