### PR TITLE
Entity query fixes

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -208,7 +208,6 @@ function createPlugin(instrumentationApi, config = {}) {
               query)
           }
 
-          debugger;
           const operationDetails = getOperationDetails(responseContext)
 
           if (operationDetails) {
@@ -336,6 +335,13 @@ function setTransactionName(transaction, transactionName) {
   }
 }
 
+/**
+ * Checks if selection is an InlineFragment that is a
+ * NamedType
+ * see: https://graphql.org/learn/queries/#inline-fragments
+ *
+ * @param {Object} selection node in grapql document AST
+ */
 function isNamedType(selection) {
   return selection.kind === 'InlineFragment' &&
     selection.typeCondition &&
@@ -355,7 +361,7 @@ function getDeepestUniqueSelection(definition) {
   let selection = definition
   while (selection.selectionSet) {
     const filtered = selection.selectionSet.selections.filter((currentSelection) => {
-      // Inline fragments describe the prior element (_entities) but contain
+      // Inline fragments describe the prior element (_entities or unions) but contain
       // selections for further naming.
       if (currentSelection.kind === 'InlineFragment') {
         return true
@@ -364,7 +370,7 @@ function getDeepestUniqueSelection(definition) {
       return IGNORED_PATH_FIELDS.indexOf(currentSelection.name.value) < 0
     })
 
-    if (filtered.length > 1 || filtered.length === 0) {
+    if (filtered.length === 0 || filtered.length > 1) {
       // selections not unique OR
       // only one IGNORED_PATH_FIELDS item in selections
       break
@@ -372,10 +378,12 @@ function getDeepestUniqueSelection(definition) {
 
     selection = filtered[0]
 
-    console.log(selection.typeCondition, selection)
     if (isNamedType(selection)) {
       const lastItemIdx = deepestPath.length - 1
-      deepestPath[lastItemIdx] = `${deepestPath[lastItemIdx]}<${selection.typeCondition.name.value}>`
+      // add type to the last item in deepestPath array
+      // (i.e - `_entities<Human>`)
+      deepestPath[lastItemIdx] =
+        `${deepestPath[lastItemIdx]}<${selection.typeCondition.name.value}>`
     } else {
       // Inline fragments do not have a name.
       selection.name && deepestPath.push(selection.name.value)

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -385,7 +385,6 @@ function getDeepestUniqueSelection(definition) {
       deepestPath[lastItemIdx] =
         `${deepestPath[lastItemIdx]}<${selection.typeCondition.name.value}>`
     } else {
-      // Inline fragments do not have a name.
       selection.name && deepestPath.push(selection.name.value)
     }
   }

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -208,6 +208,7 @@ function createPlugin(instrumentationApi, config = {}) {
               query)
           }
 
+          debugger;
           const operationDetails = getOperationDetails(responseContext)
 
           if (operationDetails) {
@@ -335,6 +336,13 @@ function setTransactionName(transaction, transactionName) {
   }
 }
 
+function isNamedType(selection) {
+  return selection.kind === 'InlineFragment' &&
+    selection.typeCondition &&
+    selection.typeCondition.kind === 'NamedType' &&
+    selection.typeCondition.name
+}
+
 /**
  * Returns the deepest path in the document definition selectionSet
  * where only one field was selected.
@@ -364,8 +372,14 @@ function getDeepestUniqueSelection(definition) {
 
     selection = filtered[0]
 
-    // Inline fragments do not have a name.
-    selection.name && deepestPath.push(selection.name.value)
+    console.log(selection.typeCondition, selection)
+    if (isNamedType(selection)) {
+      const lastItemIdx = deepestPath.length - 1
+      deepestPath[lastItemIdx] = `${deepestPath[lastItemIdx]}<${selection.typeCondition.name.value}>`
+    } else {
+      // Inline fragments do not have a name.
+      selection.name && deepestPath.push(selection.name.value)
+    }
   }
 
   return deepestPath

--- a/tests/data-definitions.js
+++ b/tests/data-definitions.js
@@ -56,6 +56,8 @@ const magazines = [
 
 function getTypeDefs(gql) {
   const typeDefs = gql`
+    union SearchResult = Book | Author
+
     type Library {
       branch: String!
       books: [Book!]
@@ -63,7 +65,7 @@ function getTypeDefs(gql) {
     }
 
     type Book {
-      title: String
+      title: String!
       isbn: String
       author: Author!
     }
@@ -78,6 +80,7 @@ function getTypeDefs(gql) {
     }
 
     type Query {
+      search(contains: String): [SearchResult!]
       books: [Book]
       hello: String
       boom: String

--- a/tests/versioned/apollo-federation/sub-graph-transactions.test.js
+++ b/tests/versioned/apollo-federation/sub-graph-transactions.test.js
@@ -71,8 +71,9 @@ function createFederatedSegmentsTests(t) {
     let transactions = []
     const expectedTransactions = [
       'WebTransaction/Expressjs/POST//query/<anonymous>/libraries.branch',
-      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities.booksInStock',
-      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities.magazinesInStock',
+      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities<Library>.booksInStock',
+      // eslint-disable-next-line max-len
+      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities<Library>.magazinesInStock',
       'WebTransaction/Expressjs/POST//query/SubGraphs/libraries'
     ]
 

--- a/tests/versioned/apollo-server-lambda/lambda-test-utils.js
+++ b/tests/versioned/apollo-server-lambda/lambda-test-utils.js
@@ -125,6 +125,10 @@ utils.executeBatchAssertResult = async function executeBatchAssertResult({
     handler(event, context, resultCallback.bind(null, t))
   } else {
     const result = await handler(event, context)
+    t.ok(result.body)
+
+    const jsonResult = JSON.parse(result.body)
+    t.equal(jsonResult.length, 2)
     checkResult(t, result, () => {
       t.end()
     })

--- a/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
+++ b/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
@@ -304,11 +304,71 @@ function createTransactionTests(t, frameworkName) {
       modVersion,
       t
     })
-    // TODO: should i add to all?
-    // t.ok(result.body)
+  })
 
-    // const jsonResult = JSON.parse(result.body)
-    // t.equal(jsonResult.length, 2)
+  t.test('union, should return deepest unique path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
+
+    const expectedName = 'GetSearchResults'
+    const query = `query ${expectedName} {
+      search(contains: "10x") {
+        __typename
+        ... on Author {
+          name
+        }
+      }
+    }`
+
+
+    const deepestPath = 'search<Author>.name'
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}/${deepestPath}`
+      )
+    })
+
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
+  })
+
+  t.test('union, multiple inline fragments, should return deepest unique path', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
+
+    const expectedName = 'GetSearchResults'
+    const query = `query ${expectedName} {
+      search(contains: "10x") {
+        __typename
+        ... on Author {
+          name
+        }
+        ... on Book {
+          title
+        }
+      }
+    }`
+
+
+    const deepestPath = 'search'
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}/${deepestPath}`
+      )
+    })
+
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
   })
 
   // there will be no document/AST nor resolved operation

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -313,6 +313,70 @@ function createTransactionTests(t, frameworkName) {
     })
   })
 
+  t.test('union, should return deepest unique path', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetSearchResult'
+    const query = `query ${expectedName} {
+      search(contains: "10x") {
+        __typename
+        ... on Author {
+          name
+        }
+      }
+    }`
+
+    const deepestPath = 'search<Author>.name'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}/${deepestPath}`
+      )
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
+  t.test('union, multiple inline fragments, should return deepest unique path', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetSearchResult'
+    const query = `query ${expectedName} {
+      search(contains: "10x") {
+        __typename
+        ... on Author {
+          name
+        }
+        ... on Book {
+          title
+        }
+      }
+    }`
+
+    const deepestPath = 'search'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}/${deepestPath}`
+      )
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
+
   // there will be no document/AST nor resolved operation
   t.test('if the query cannot be parsed, should be named /*', (t) => {
     const { helper, serverUrl } = t.context


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Improved transaction names that contain InlineFragments(federated sub-graph calls, and union types)

## Links
Closes #105 

## Details
You can look at the added tests for union types and changes to the sub graph entity queries.  The solution was to go with 2nd option from #106 `_entities<Library>.booksInStock`.  
