### PR TITLE
Add test for alias in query and update readme for union types

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -106,7 +106,7 @@ Would result in the deepest unique path of: 'libraries.branch'.
 
 ## Union Types and Inline Fragments
 
-For Union types which utilize Inline Fragments, the transaction name will use `< ... >` brackets to indicate the underlying type returned by the Union query if only one result is specified in the query.
+For Union types which utilize Inline Fragments, the transaction name will use `< ... >` brackets to indicate the underlying selected field for the Union query if only one result is specified in the query.
 
 For the following schema:
 ```

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -104,6 +104,64 @@ query {
 
 Would result in the deepest unique path of: 'libraries.branch'.
 
+## Union Types and Inline Fragments
+
+For Union types which utilize Inline Fragments, the transaction name will use `< ... >` brackets to indicate the underlying type returned by the Union query if only one result is specified in the query.
+
+For the following schema:
+```
+union SearchResult = Book | Author
+
+type Book {
+  title: String!
+}
+
+type Author {
+  name: String!
+}
+
+type Query {
+  search(contains: String): [SearchResult!]
+}
+```
+
+and the following query:
+
+```
+query example {
+  search(contains: "author") {
+    __typename
+    ... on Author {
+      name
+    }
+  }
+}
+```
+
+Would result in the following transaction name:
+
+`post /query/example/search<Author>.name`
+
+However, if the query is returning both Book and Author:
+
+```
+query example {
+  search(contains: "author") {
+    __typename
+    ... on Author {
+      name
+    }
+    ... on Book {
+      title
+    }
+  }
+}
+```
+
+The resulting transaction name would be:
+
+`post /query/example/search`
+
 ## Naming on Error
 
 Errors parsing or validating a GraphQL request can impact transaction naming.

--- a/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
+++ b/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
@@ -138,6 +138,39 @@ function createTransactionTests(t, frameworkName) {
     })
   })
 
+  t.test('named query, multi-level with aliases should ignore aliases in naming', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
+
+    const expectedName = 'GetBooksByLibrary'
+    const query = `query ${expectedName} {
+      libAlias: libraries {
+        bookAlias: books {
+          title
+          author {
+            name
+          }
+        }
+      }
+    }`
+
+    const path = 'libraries.books'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}/${path}`
+      )
+    })
+
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
+  })
+
   t.test('anonymous mutation, single level, should use anonymous placeholder', (t) => {
     const { helper, patchedHandler, stubContext, modVersion } = t.context
 

--- a/tests/versioned/attributes-tests.js
+++ b/tests/versioned/attributes-tests.js
@@ -188,6 +188,78 @@ function createAttributesTests(t) {
     })
   })
 
+  t.test('query with alias should use alias in path attributes', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBooksByLibrary'
+    const query = `query ${expectedName} {
+      alias: libraries {
+        books {
+          title
+          author {
+            name
+          }
+        }
+      }
+    }`
+
+    const deepestPath = 'libraries.books'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}/${deepestPath}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+
+      const expectedOperationAttributes = {
+        'graphql.operation.type': 'query',
+        'graphql.operation.name': expectedName
+      }
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        operationAttributes,
+        expectedOperationAttributes,
+        'should have operation attributes'
+      )
+
+      const [resolveLibrariesSegment, resolveBooksSegment] = operationSegment.children
+
+      const expectedLibrariesAttributes = {
+        'graphql.field.name': 'libraries',
+        'graphql.field.returnType': '[Library]',
+        'graphql.field.parentType': 'Query',
+        'graphql.field.path': 'alias'
+      }
+
+      const resolveLibrariesAttributes
+         = resolveLibrariesSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveLibrariesAttributes,
+        expectedLibrariesAttributes,
+        'should have field resolve attributes for libraries'
+      )
+
+      const expectedBooksAttributes = {
+        'graphql.field.name': 'books',
+        'graphql.field.returnType': '[Book!]',
+        'graphql.field.parentType': 'Library',
+        'graphql.field.path': 'alias.book'
+      }
+
+      const resolveBooksAttributes
+         = resolveBooksSegment.attributes.get(SEGMENT_DESTINATION)
+      t.matches(
+        resolveBooksAttributes,
+        expectedBooksAttributes,
+        'should have field resolve attributes for books'
+      )
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
   t.test('named mutation should capture all standard attributes', (t) => {
     const { helper, serverUrl } = t.context
 

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -149,6 +149,38 @@ function createTransactionTests(t, frameworkName) {
     })
   })
 
+  t.test('named query, multi-level with aliases should ignore aliases in naming', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBooksByLibrary'
+    const query = `query ${expectedName} {
+      libAlias: libraries {
+        bookAlias: books {
+          title
+          author {
+            name
+          }
+        }
+      }
+    }`
+
+    const path = 'libraries.books'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(
+        transaction.name,
+        `${EXPECTED_PREFIX}//query/${expectedName}/${path}`
+      )
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
   t.test('anonymous mutation, single level, should use anonymous placeholder', (t) => {
     const { helper, serverUrl } = t.context
 


### PR DESCRIPTION
## Details
This PR adds tests for query aliases and adds some documentation around how the plugin handles union types/inline fragments.

Closes: #44 


