### PR TITLE
update query obfuscation to use graphql document definitions

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -188,21 +188,13 @@ function createPlugin(instrumentationApi, config = {}) {
           let transactionName = '*'
           let segmentName = UNKNOWN_OPERATION
 
-          // always use context.source so we can get both queries and persisted queries
-          // see: https://github.com/apollographql/apollo-server/blob/2bccec2c5f5adaaf785f13ab98b6e52e22d5b22e/packages/apollo-server-core/src/requestPipeline.ts#L232
-          let query = responseContext.source
-
-          if (query) {
-            // attempt to extract arguments to strip from query
-            query = cleanQuery(query)
-
-            operationSegment.addAttribute(OPERATION_QUERY_ATTR, query)
-          }
-
           const operationDetails = getOperationDetails(responseContext)
 
           if (operationDetails) {
-            const { operationName, operationType, deepestUniquePath } = operationDetails
+            const { operationName, operationType, deepestUniquePath, cleanedQuery } =
+              operationDetails
+
+            operationSegment.addAttribute(OPERATION_QUERY_ATTR, cleanedQuery)
 
             operationSegment.addAttribute(OPERATION_TYPE_ATTR, operationType)
 
@@ -239,7 +231,7 @@ function getOperationDetails(responseContext) {
     return null
   }
 
-  return getDetailsFromDocument(responseContext.document)
+  return getDetailsFromDocument(responseContext)
 }
 
 function isScalar(fieldInfo) {
@@ -271,17 +263,24 @@ function isTopLevelField(fieldInfo) {
   return result
 }
 
-function getDetailsFromDocument(document) {
-  const [definition] = document.definitions
+function getDetailsFromDocument(responseContext) {
+  const [definition] = responseContext.document.definitions
 
-  const deepestUniquePath = getDeepestUniqueSelection(definition)
+  const pathAndArgs = getDeepestPathAndQueryArguments(definition)
+
+  // always use context.source so we can get both queries and persisted queries
+  // see: https://github.com/apollographql/apollo-server/blob/2bccec2c5f5adaaf785f13ab98b6e52e22d5b22e/packages/apollo-server-core/src/requestPipeline.ts#L232
+  let query = cleanQuery(responseContext.source, pathAndArgs.argLocations)
+
+  const deepestUniquePath = pathAndArgs.deepestPath
 
   const definitionName = definition.name && definition.name.value
 
   return {
     operationType: definition.operation,
     operationName: definitionName,
-    deepestUniquePath: deepestUniquePath.join('.')
+    deepestUniquePath: deepestUniquePath.join('.'),
+    cleanedQuery: query
   }
 }
 
@@ -337,47 +336,77 @@ function isNamedType(selection) {
 }
 
 /**
- * Returns the deepest path in the document definition selectionSet
- * where only one field was selected.
+ * Returns an object with the deepest path in the document definition selectionSet
+ * along with query argument locations in raw query string.
+ * Deepest path is built from field names where only one field is in selectionSet.
  *
  * 'id' and '__typename' fields are filtered out of consideration to improve
- * naming in sub graph scenarioes.
+ * naming in sub graph scenarios.
  */
-function getDeepestUniqueSelection(definition) {
-  const deepestPath = []
-  let selection = definition
-  while (selection.selectionSet) {
-    const filtered = selection.selectionSet.selections.filter((currentSelection) => {
-      // Inline fragments describe the prior element (_entities or unions) but contain
-      // selections for further naming.
-      if (currentSelection.kind === 'InlineFragment') {
-        return true
-      }
+function getDeepestPathAndQueryArguments(definition) {
+  let deepestPath = null
+  let foundDeepestPath = false
+  let argLocations = []
 
-      return IGNORED_PATH_FIELDS.indexOf(currentSelection.name.value) < 0
-    })
+  definition.selectionSet.selections.forEach((selection) => {
+    searchSelection(selection)
+  })
 
-    if (filtered.length === 0 || filtered.length > 1) {
-      // selections not unique OR
-      // only one IGNORED_PATH_FIELDS item in selections
-      break
-    }
-
-    selection = filtered[0]
-
-    if (isNamedType(selection)) {
-      const lastItemIdx = deepestPath.length - 1
-      const lastItem = deepestPath[lastItemIdx]
-      const selectedType = selection.typeCondition.name.value
-      // add type to the last item in deepestPath array
-      // (i.e - `_entities<Human>`)
-      deepestPath[lastItemIdx] = `${lastItem}<${selectedType}>`
-    } else {
-      selection.name && deepestPath.push(selection.name.value)
-    }
+  return {
+    deepestPath,
+    argLocations
   }
 
-  return deepestPath
+  /**
+   * Search each selection path until no-more sub-selections
+   * exist. If the curent path is deeper than deepestPath,
+   * deepestPath is replaced.
+   */
+  function searchSelection(selection, currentParts) {
+    const parts = currentParts ? [...currentParts] : []
+
+    if (selection.arguments && selection.arguments.length > 0) {
+      selection.arguments.forEach((arg) => {
+        argLocations.push(arg.loc)
+      })
+    }
+
+    if (!foundDeepestPath) {
+      if (isNamedType(selection)) {
+        const lastItemIdx = parts.length - 1
+        // add type to the last item in parts array
+        // (i.e - `_entities<Human>`)
+        parts[lastItemIdx] = `${parts[lastItemIdx]}<${selection.typeCondition.name.value}>`
+      } else {
+        selection.name &&
+          IGNORED_PATH_FIELDS.indexOf(selection.name.value) < 0 &&
+          parts.push(selection.name.value)
+      }
+    }
+
+    // end if no more selections
+    if (selection.selectionSet) {
+      const filtered = selection.selectionSet.selections.filter((currentSelection) => {
+        // Inline fragments describe the prior element (_entities or unions) but contain
+        // selections for further naming.
+        if (currentSelection.kind === 'InlineFragment') {
+          return true
+        }
+
+        return IGNORED_PATH_FIELDS.indexOf(currentSelection.name.value) < 0
+      })
+
+      if (filtered.length === 0 || filtered.length > 1) {
+        foundDeepestPath = true
+      }
+
+      filtered.forEach((innerSelection) => {
+        searchSelection(innerSelection, parts)
+      })
+    } else if (!deepestPath || parts.length > deepestPath.length) {
+      deepestPath = parts
+    }
+  }
 }
 
 function recordResolveSegment(segment, scope) {

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -390,7 +390,7 @@ function getDeepestPathAndQueryArguments(definition) {
     // end if no more selections
     if (selection.selectionSet) {
       // Filter selections used for naming
-      const filtered = filterSelectionsForDeepestPath(selection.selectionSet)
+      const filtered = filterSelectionsForDeepestPath(selection.selectionSet.selections)
 
       // When no selections returned from filtering, deepest path is found
       if (filtered.length === 0 || filtered.length > 1) {

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -365,6 +365,7 @@ function getDeepestPathAndQueryArguments(definition) {
   function searchSelection(selection, currentParts) {
     const parts = currentParts ? [...currentParts] : []
 
+    // capture the arguments for a selection
     if (selection.arguments && selection.arguments.length > 0) {
       selection.arguments.forEach((arg) => {
         argLocations.push(arg.loc)
@@ -372,12 +373,14 @@ function getDeepestPathAndQueryArguments(definition) {
     }
 
     if (!foundDeepestPath) {
+      // Build up deepest path
       if (isNamedType(selection)) {
         const lastItemIdx = parts.length - 1
         // add type to the last item in parts array
         // (i.e - `_entities<Human>`)
         parts[lastItemIdx] = `${parts[lastItemIdx]}<${selection.typeCondition.name.value}>`
       } else {
+        // Add selection name to deepest path
         selection.name &&
           IGNORED_PATH_FIELDS.indexOf(selection.name.value) < 0 &&
           parts.push(selection.name.value)
@@ -386,24 +389,20 @@ function getDeepestPathAndQueryArguments(definition) {
 
     // end if no more selections
     if (selection.selectionSet) {
-      const filtered = selection.selectionSet.selections.filter((currentSelection) => {
-        // Inline fragments describe the prior element (_entities or unions) but contain
-        // selections for further naming.
-        if (currentSelection.kind === 'InlineFragment') {
-          return true
-        }
+      // Filter selections used for naming
+      const filtered = filterSelectionsForDeepestPath(selection.selectionSet)
 
-        return IGNORED_PATH_FIELDS.indexOf(currentSelection.name.value) < 0
-      })
-
+      // When no selections returned from filtering, deepest path is found
       if (filtered.length === 0 || filtered.length > 1) {
         foundDeepestPath = true
       }
 
+      // Recurse through inner selections
       filtered.forEach((innerSelection) => {
         searchSelection(innerSelection, parts)
       })
     } else if (!deepestPath || parts.length > deepestPath.length) {
+      // Add selection parts to deepest path if we're not done
       deepestPath = parts
     }
   }
@@ -425,6 +424,18 @@ function recordResolveSegment(segment, scope) {
     const fieldNameMetric = `${RESOLVE_PREFIX}/${fieldName}`
     createMetricPairs(transaction, fieldNameMetric, scope, duration, exclusive)
   }
+}
+
+function filterSelectionsForDeepestPath(selections) {
+  return selections.filter((currentSelection) => {
+    // Inline fragments describe the prior element (_entities or unions) but contain
+    // selections for further naming.
+    if (currentSelection.kind === 'InlineFragment') {
+      return true
+    }
+
+    return IGNORED_PATH_FIELDS.indexOf(currentSelection.name.value) < 0
+  })
 }
 
 function recordOperationSegment(segment, scope) {

--- a/lib/query-utils.js
+++ b/lib/query-utils.js
@@ -5,10 +5,22 @@
 
 'use strict'
 
-const cleanQuery = (query) => {
-  const regex = /\([\s\S]+?[^\)]\)/g
+const OBFUSCATION_STR = '***'
 
-  return query.replace(regex, '(***)')
+const cleanQuery = (query, argLocations) => {
+  let cleanedQuery = query
+  let offset = 0
+
+  argLocations.forEach((loc) => {
+    cleanedQuery =
+      cleanedQuery.slice(0, loc.start - offset) +
+      OBFUSCATION_STR +
+      cleanedQuery.slice(loc.end - offset)
+
+    offset = loc.end - loc.start - OBFUSCATION_STR.length
+  })
+
+  return cleanedQuery
 }
 
 module.exports = cleanQuery

--- a/tests/data-definitions.js
+++ b/tests/data-definitions.js
@@ -19,25 +19,29 @@ const books = [
     title: 'Node Agent: The Book',
     isbn: 'a-fake-isbn',
     author: 'Sentient Bits',
-    branch: 'riverside'
+    branch: 'riverside',
+    category: 'NOVEL'
   },
   {
     title: "Ollies for O11y: A Sk8er's Guide to Observability",
     isbn: 'a-second-fake-isbn',
     author: 'Faux Hawk',
-    branch: 'downtown'
+    branch: 'downtown',
+    category: 'COOKBOOK'
   },
   {
     title: '[Redacted]',
     isbn: 'a-third-fake-isbn',
     author: 'Closed Telemetry',
-    branch: 'riverside'
+    branch: 'riverside',
+    category: 'NOVEL'
   },
   {
     title: 'Be a hero: fixing the things you broke',
     isbn: 'a-fourth-fake-isbn',
     author: '10x Developer',
-    branch: 'downtown'
+    branch: 'downtown',
+    category: 'COOKBOOK'
   }
 ]
 
@@ -65,7 +69,7 @@ function getTypeDefs(gql) {
 
     type Library {
       branch: String!
-      books: [Book!]
+      books(category: BookCategory): [Book!]
       magazines: [Magazine]
     }
 
@@ -73,6 +77,12 @@ function getTypeDefs(gql) {
       title: String!
       isbn: String
       author: Author!
+      category: BookCategory
+    }
+
+    enum BookCategory {
+      NOVEL
+      COOKBOOK
     }
 
     type Author {
@@ -86,7 +96,7 @@ function getTypeDefs(gql) {
 
     type Query {
       search(contains: String): [SearchResult!]
-      books: [Book]
+      books(category: BookCategory): [Book]!
       hello: String
       boom: String
       paramQuery(blah: String!, blee: String): String!

--- a/tests/unit/query-utils.test.js
+++ b/tests/unit/query-utils.test.js
@@ -30,6 +30,26 @@ tap.test('Obfuscate GraphQL query args tests', (t) => {
     t.end()
   })
 
+  t.test('Should obfuscate aliased query args for aliased', (t) => {
+    const query = `query thing: logans(run: "(333") {
+      runner
+    }`
+
+    const argLocations = [
+      {
+        start: 20,
+        end: 31
+      }
+    ]
+
+    const newQuery = cleanQuery(query, argLocations)
+
+    t.notOk(newQuery.includes('333'))
+    t.ok(newQuery.includes('logans(***)'))
+
+    t.end()
+  })
+
   t.test('Should obfuscate multiple args', (t) => {
     const query = `query chickens(hens: 'yes') {
       eggs(yolk: 'yes') {

--- a/tests/unit/query-utils.test.js
+++ b/tests/unit/query-utils.test.js
@@ -10,82 +10,50 @@ const tap = require('tap')
 const cleanQuery = require('../../lib/query-utils')
 
 tap.test('Obfuscate GraphQL query args tests', (t) => {
-  t.test('Should remove new line and tabs', (t) => {
-    const query = `query {
+  t.test('Should obfuscate query args', (t) => {
+    const query = `query logans(run: "(333") {
       runner
     }`
 
-    const newQuery = cleanQuery(query)
+    const argLocations = [
+      {
+        start: 13,
+        end: 24
+      }
+    ]
 
-    t.equal(newQuery, query)
-
-    t.end()
-  })
-
-  t.test('Should hide one arg', (t) => {
-    const query = `query logans(run: 333) {
-      runner
-    }`
-
-    const newQuery = cleanQuery(query)
+    const newQuery = cleanQuery(query, argLocations)
 
     t.notOk(newQuery.includes('333'))
+    t.ok(newQuery.includes('logans(***)'))
 
     t.end()
   })
 
   t.test('Should obfuscate multiple args', (t) => {
-    const query = `query chickens(hens: 'yes', eggs: 0) {
-      eggs(yolk: 'yes')
-    }`
-
-    const newQuery = cleanQuery(query)
-
-    t.notOk(newQuery.includes('yes'))
-    t.notOk(newQuery.includes('0'))
-    t.ok('chickens(***)')
-    t.ok('eggs(***)', 'subquery args')
-
-    t.end()
-  })
-
-  t.test('Should not obfuscate aliases', (t) => {
-    const query = `query {
-      pony: horse(horseId: 4, color: 'brown') {
-        horse
+    const query = `query chickens(hens: 'yes') {
+      eggs(yolk: 'yes') {
+        yolk
       }
     }`
 
-    const newQuery = cleanQuery(query)
+    const argLocations = [
+      {
+        start: 15,
+        end: 26
+      },
+      {
+        start: 41,
+        end: 52
+      }
+    ]
 
-    t.ok(newQuery.includes('pony: horse'), 'alias is intact')
-    t.ok(newQuery.includes('horse(***)'))
+    const newQuery = cleanQuery(query, argLocations)
 
-    t.end()
-  })
-
-  t.test('Should obfuscate mutation args', (t) => {
-    const query = `mutation corn(husks: {
-      husky: 'yes',
-      id: 5
-    })`
-
-    const newQuery = cleanQuery(query)
-
-    t.ok(newQuery.includes('corn(***)'))
-
-    t.end()
-  })
-
-  t.test('Should obfuscate variable placeholders', (t) => {
-    const query = `query ParamQueryWithArgs($arg1: String!, $arg2: String) {
-      paramQuery(blah: $arg1, blee: $arg2)
-    }`
-
-    const newQuery = cleanQuery(query)
-
-    t.ok(newQuery.includes('ParamQueryWithArgs(***)'))
-    t.ok(newQuery.includes('paramQuery(***)'))
+    t.notOk(newQuery.includes('hens'))
+    t.notOk(newQuery.includes('yolk:'))
+    t.ok(newQuery.includes('chickens(***)'))
+    t.ok(newQuery.includes('eggs(***)'))
 
     t.end()
   })

--- a/tests/unit/query-utils.test.js
+++ b/tests/unit/query-utils.test.js
@@ -45,7 +45,28 @@ tap.test('Obfuscate GraphQL query args tests', (t) => {
     const newQuery = cleanQuery(query, argLocations)
 
     t.notOk(newQuery.includes('333'))
-    t.ok(newQuery.includes('logans(***)'))
+    t.ok(newQuery.includes('thing: logans', 'alias is intact'))
+    t.ok(newQuery.includes('logans(***)', 'args obfuscated'))
+
+    t.end()
+  })
+
+  t.test('Should obfuscate mutation args', (t) => {
+    const argLocations = [
+      {
+        start: 14,
+        end: 60
+      }
+    ]
+
+    const query = `mutation corn(husks: {
+      husky: 'yes',
+      id: 5
+    })`
+
+    const newQuery = cleanQuery(query, argLocations)
+
+    t.ok(newQuery.includes('corn(***)'))
 
     t.end()
   })

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -14,9 +14,10 @@
       },
       "files": [
         "segments.test.js",
-        "service-definition-and-healthcheck-filtering.test.js",
         "transaction-naming.test.js",
-        "sub-graph-transactions.test.js"
+        "service-definition-and-healthcheck-filtering.test.js",
+        "sub-graph-transactions.test.js",
+        "query-obfuscation.test.js"
       ]
     },
     {
@@ -33,7 +34,8 @@
         "segments.test.js",
         "service-definition-and-healthcheck-filtering.test.js",
         "transaction-naming.test.js",
-        "sub-graph-transactions.test.js"
+        "sub-graph-transactions.test.js",
+        "query-obfuscation.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-federation/query-obfuscation.test.js
+++ b/tests/versioned/apollo-federation/query-obfuscation.test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { setupFederatedGatewayServerTests } = require('./federated-gateway-server-setup')
+
+const { executeQuery } = require('../../test-client')
+const { checkResult } = require('../common')
+
+const SEGMENT_DESTINATION = 0x20
+
+const ANON_PLACEHOLDER = '<anonymous>'
+
+const QUERY_ATTRIBUTE_NAME = 'graphql.operation.query'
+
+setupFederatedGatewayServerTests({
+  suiteName: 'query obfuscation',
+  createTests: createQueryObfuscaionTests
+})
+
+/**
+ * Creates a set of standard transction tests to run against various
+ * apollo-server libraries.
+ * It is required that t.context.helper and t.context.serverUrl are set.
+ * @param {*} t a tap test instance
+ */
+function createQueryObfuscaionTests(t) {
+  const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer/query'
+
+  t.test('Obfuscates query arguments', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const query = `query {
+      library(id: 3) {
+        booksInStock {
+          title
+        }
+      }
+    }`
+
+    const path = 'library.booksInStock.title'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationName = `${OPERATION_PREFIX}/${ANON_PLACEHOLDER}/${path}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+
+      // only test one operation segment of three federated server transactions
+      if (operationSegment) {
+        const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+
+        t.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('library(***)') > 0)
+      }
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+}
+
+function findSegmentByName(root, name) {
+  if (root.name === name) {
+    return root
+  } else if (root.children && root.children.length) {
+    for (let i = 0; i < root.children.length; i++) {
+      const child = root.children[i]
+      const found = findSegmentByName(child, name)
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return null
+}

--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -15,7 +15,8 @@
         "transaction-naming.test.js",
         "segments.test.js",
         "errors.test.js",
-        "attributes.test.js"
+        "attributes.test.js",
+        "query-obfuscation.tests.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-express/query-obfuscation.tests.js
+++ b/tests/versioned/apollo-server-express/query-obfuscation.tests.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { setupApolloServerExpressTests } = require('./apollo-server-express-setup')
+const queryObfuscationTests = require('../query-obfuscation-tests')
+
+setupApolloServerExpressTests(queryObfuscationTests)

--- a/tests/versioned/apollo-server-fastify/package.json
+++ b/tests/versioned/apollo-server-fastify/package.json
@@ -15,7 +15,8 @@
         "segments.test.js",
         "transaction-naming.test.js",
         "errors.test.js",
-        "attributes.test.js"
+        "attributes.test.js",
+        "query-obfuscation.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-fastify/query-obfuscation.test.js
+++ b/tests/versioned/apollo-server-fastify/query-obfuscation.test.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { setupApolloServerFastifyTests } = require('./apollo-server-fastify-setup')
+const queryObfuscationTests = require('../query-obfuscation-tests')
+
+setupApolloServerFastifyTests(queryObfuscationTests)

--- a/tests/versioned/apollo-server-hapi/package.json
+++ b/tests/versioned/apollo-server-hapi/package.json
@@ -15,7 +15,8 @@
         "segments.test.js",
         "transaction-naming.test.js",
         "errors.test.js",
-        "attributes.test.js"
+        "attributes.test.js",
+        "query-obfuscation.test.js"
       ]
     },
     {
@@ -30,7 +31,8 @@
         "segments.test.js",
         "transaction-naming.test.js",
         "errors.test.js",
-        "attributes.test.js"
+        "attributes.test.js",
+        "query-obfuscation.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-hapi/query-obfuscation.test.js
+++ b/tests/versioned/apollo-server-hapi/query-obfuscation.test.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { setupApolloServerHapiTests } = require('./apollo-server-hapi-setup')
+const queryObfuscationTests = require('../query-obfuscation-tests')
+
+setupApolloServerHapiTests(queryObfuscationTests)

--- a/tests/versioned/apollo-server-koa/package.json
+++ b/tests/versioned/apollo-server-koa/package.json
@@ -15,7 +15,8 @@
         "segments.test.js",
         "transaction-naming.test.js",
         "errors.test.js",
-        "attributes.test.js"
+        "attributes.test.js",
+        "query-obfuscation.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-koa/query-obfuscation.test.js
+++ b/tests/versioned/apollo-server-koa/query-obfuscation.test.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { setupApolloServerKoaTests } = require('./apollo-server-koa-setup')
+const queryObfuscationTests = require('../query-obfuscation-tests')
+
+setupApolloServerKoaTests(queryObfuscationTests)

--- a/tests/versioned/apollo-server-lambda/attributes-tests.js
+++ b/tests/versioned/apollo-server-lambda/attributes-tests.js
@@ -494,43 +494,6 @@ function createAttributesTests(t) {
     })
   })
 
-  t.test('query with args should have args obfuscated in raw query attribute', (t) => {
-    const { helper, patchedHandler, stubContext, modVersion } = t.context
-
-    const expectedName = 'ParamQueryWithArgs'
-    const query = `query ${expectedName}($arg1: String!, $arg2: String) {
-      paramQuery(blah: $arg1, blee: $arg2)
-    }`
-
-    const queryJson = {
-      operationName: expectedName,
-      query: query,
-      variables: {
-        arg1: 'first',
-        arg2: 'second'
-      }
-    }
-
-    helper.agent.on('transactionFinished', (transaction) => {
-      const operationName = `${OPERATION_PREFIX}/query/${expectedName}/paramQuery`
-
-      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
-
-      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
-
-      t.ok(operationAttributes['graphql.operation.query'].includes(`${expectedName}(***)`))
-      t.ok(operationAttributes['graphql.operation.query'].includes('paramQuery(***)'))
-    })
-
-    executeQueryJson({
-      handler: patchedHandler,
-      query: queryJson,
-      context: stubContext,
-      modVersion,
-      t
-    })
-  })
-
   t.test('union, should capture all expected attributes', (t) => {
     const { helper, patchedHandler, stubContext, modVersion } = t.context
 

--- a/tests/versioned/apollo-server-lambda/package.json
+++ b/tests/versioned/apollo-server-lambda/package.json
@@ -14,7 +14,8 @@
         "segments.test.js",
         "attributes-tests.js",
         "transaction-naming-tests.js",
-        "errors-tests.js"
+        "errors-tests.js",
+        "query-obfuscation-tests.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server-lambda/query-obfuscation-tests.js
+++ b/tests/versioned/apollo-server-lambda/query-obfuscation-tests.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { executeQueryAssertResult } = require('./lambda-test-utils')
+const { findSegmentByName } = require('../../agent-testing')
+
+const SEGMENT_DESTINATION = 0x20
+
+const QUERY_ATTRIBUTE_NAME = 'graphql.operation.query'
+
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+
+const { setupApolloServerLambdaTests } = require('./apollo-server-lambda-setup')
+
+setupApolloServerLambdaTests({
+  suiteName: 'lambda query obfuscation',
+  createTests: createQueryObfuscationTests,
+  pluginConfig: {
+    captureScalars: true
+  }
+})
+
+function createQueryObfuscationTests(t) {
+  t.test('Obfuscates query arguments', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
+
+    const expectedName = 'GetBooksByLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "rivers)i{de") {
+        magazines {
+          title
+        }
+      }
+    }`
+
+    const path = 'library.magazines.title'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}/${path}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+
+      t.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('library(***)') > 0)
+    })
+
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      modVersion,
+      t
+    })
+  })
+}

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -15,7 +15,8 @@
         "segments.test.js",
         "agent-disabled.test.js",
         "errors.test.js",
-        "attributes.test.js"
+        "attributes.test.js",
+        "query-obfuscation.test.js"
       ]
     }
   ],

--- a/tests/versioned/apollo-server/query-obfuscation.test.js
+++ b/tests/versioned/apollo-server/query-obfuscation.test.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { setupApolloServerTests } = require('../../apollo-server-setup')
+const queryObfuscationTests = require('../query-obfuscation-tests')
+
+setupApolloServerTests(queryObfuscationTests)

--- a/tests/versioned/attributes-tests.js
+++ b/tests/versioned/attributes-tests.js
@@ -460,40 +460,6 @@ function createAttributesTests(t) {
     })
   })
 
-  t.test('query with args should have args obfuscated in raw query attribute', (t) => {
-    const { helper, serverUrl } = t.context
-
-    const expectedName = 'ParamQueryWithArgs'
-    const query = `query ${expectedName}($arg1: String!, $arg2: String) {
-      paramQuery(blah: $arg1, blee: $arg2)
-    }`
-
-    const queryJson = {
-      operationName: expectedName,
-      query: query,
-      variables: {
-        arg1: 'first',
-        arg2: 'second'
-      }
-    }
-
-    helper.agent.on('transactionFinished', (transaction) => {
-      const operationName = `${OPERATION_PREFIX}/query/${expectedName}/paramQuery`
-
-      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
-
-      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
-
-      t.ok(operationAttributes['graphql.operation.query'].includes(`${expectedName}(***)`))
-      t.ok(operationAttributes['graphql.operation.query'].includes('paramQuery(***)'))
-    })
-
-    executeJson(serverUrl, queryJson, (err) => {
-      t.error(err)
-      t.end()
-    })
-  })
-
   t.test('union, should capture all expected attributes', (t) => {
     const { helper, serverUrl } = t.context
 

--- a/tests/versioned/query-obfuscation-tests.js
+++ b/tests/versioned/query-obfuscation-tests.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const { executeQuery } = require('../test-client')
+const { checkResult } = require('./common')
+
+const SEGMENT_DESTINATION = 0x20
+
+const ANON_PLACEHOLDER = '<anonymous>'
+
+const QUERY_ATTRIBUTE_NAME = 'graphql.operation.query'
+
+/**
+ * Creates a set of standard transction tests to run against various
+ * apollo-server libraries.
+ * It is required that t.context.helper and t.context.serverUrl are set.
+ * @param {*} t a tap test instance
+ */
+function createQueryObfuscaionTests(t) {
+  const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer/query'
+
+  t.test('Obfuscates query arguments and nested query arguments', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const query = `query {
+      library(branch: "riverside") {
+        magazines {
+          title
+        },
+        books(category: NOVEL) {
+          title
+        }
+      }
+    }`
+
+    const path = 'library'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationName = `${OPERATION_PREFIX}/${ANON_PLACEHOLDER}/${path}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+
+      t.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('library(***)') > 0)
+      t.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('books(***)') > 0)
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
+  t.test('Obfuscates query arguments with parenthesis and brackets', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const query = `query {
+      library(branch: "rivers)i{de") {
+        magazines {
+          title
+        }
+      }
+    }`
+
+    const path = 'library.magazines.title'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationName = `${OPERATION_PREFIX}/${ANON_PLACEHOLDER}/${path}`
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+
+      t.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('library(***)') > 0)
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+}
+
+function findSegmentByName(root, name) {
+  if (root.name === name) {
+    return root
+  } else if (root.children && root.children.length) {
+    for (let i = 0; i < root.children.length; i++) {
+      const child = root.children[i]
+      const found = findSegmentByName(child, name)
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return null
+}
+
+module.exports = {
+  suiteName: 'query obfuscation',
+  createTests: createQueryObfuscaionTests
+}

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -80,6 +80,34 @@ function createTransactionTests(t, frameworkName) {
     }
   )
 
+  t.test('Nested queries with arguments', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const query = `query {
+      library(branch: "riverside") {
+        magazines {
+          title
+        },
+        books(category: NOVEL) {
+          title
+        }
+      }
+    }`
+
+    const path = 'library'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//query/${ANON_PLACEHOLDER}/${path}`)
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
   t.test('anonymous query, multi-level should return deepest unique path', (t) => {
     const { helper, serverUrl } = t.context
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Updated query argument obfuscation logic to use document definition rather than regex.
* **BREAKING**: Un-parsable queries will not be added as a `graphql.operation.query` attribute. 
## Links
Closes: #122 
## Details
This change fixes an edge case where a query argument like `query(stuff: "st)")` would cause the wrong part of the query to be obfuscated. To better capture arguments to obfuscate, we decided to leverage the document definition. If the query was not parsable, we do not have access to the document definition. Thus, we made the decision to not add the raw query as a `graphql.operation.query` attribute if the query was not parsable.