### PR TITLE
Fixes (and temporarily patches) versioned tests to get past failures

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -30,6 +30,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 * [lint-staged](#lint-staged)
 * [newrelic](#newrelic)
 * [prettier](#prettier)
+* [sinon](#sinon)
 * [tap](#tap)
 
 
@@ -666,7 +667,7 @@ This product includes source derived from [@newrelic/test-utilities](https://git
 
 ### apollo-server
 
-This product includes source derived from [apollo-server](https://github.com/apollographql/apollo-server) ([v2.18.2](https://github.com/apollographql/apollo-server/tree/v2.18.2)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v2.18.2/LICENSE):
+This product includes source derived from [apollo-server](https://github.com/apollographql/apollo-server) ([v2.25.2](https://github.com/apollographql/apollo-server/tree/v2.25.2)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v2.25.2/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -1105,6 +1106,41 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
+### sinon
+
+This product includes source derived from [sinon](https://github.com/sinonjs/sinon) ([v11.1.2](https://github.com/sinonjs/sinon/tree/v11.1.2)), distributed under the [BSD-3-Clause License](https://github.com/sinonjs/sinon/blob/v11.1.2/LICENSE):
+
+```
+(The BSD License)
+
+Copyright (c) 2010-2017, Christian Johansen, christian@cjohansen.no
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of Christian Johansen nor the names of his contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run unit && npm run integration && npm run versioned",
     "third-party-updates": "oss third-party manifest && oss third-party notices && git add THIRD_PARTY_NOTICES.md third_party_manifest.json",
     "unit": "tap --test-regex='(\\/|^tests\\/unit\\/.*\\.test\\.js)$' --no-coverage",
-    "versioned": "npm run versioned:npm6",
+    "versioned": "npm run versioned:npm7",
     "versioned:folder": "versioned-tests --minor -i 2",
     "versioned:npm6": "versioned-tests --minor -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
     "versioned:npm7": "versioned-tests --minor --all -i 2 'tests/versioned/*'"

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/federation": ">=0.25.2",
         "@apollo/gateway": {
-          "versions": ">=0.31.0",
+          "versions": ">=0.31.0 <0.41",
           "samples": 3
         },
         "@opentelemetry/api": "1.0.1",

--- a/tests/versioned/apollo-server-koa/package.json
+++ b/tests/versioned/apollo-server-koa/package.json
@@ -8,8 +8,24 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-koa": ">=2.14.0",
+        "apollo-server-koa": ">=2.14.0 <3.0.2",
         "koa": ">=2.13.0"
+      },
+      "files": [
+        "segments.test.js",
+        "transaction-naming.test.js",
+        "errors.test.js",
+        "attributes.test.js",
+        "query-obfuscation.test.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=12"
+      },
+      "dependencies": {
+        "apollo-server-koa": ">=3.4.0",
+        "koa": ">=2.13.1"
       },
       "files": [
         "segments.test.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Aug 27 2021 14:49:11 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed Oct 13 2021 16:45:37 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -45,15 +45,15 @@
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "apollo-server@2.18.2": {
+    "apollo-server@2.25.2": {
       "name": "apollo-server",
-      "version": "2.18.2",
+      "version": "2.25.2",
       "range": "^2.18.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/apollographql/apollo-server",
-      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v2.18.2",
+      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v2.25.2",
       "licenseFile": "node_modules/apollo-server/LICENSE",
-      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v2.18.2/LICENSE",
+      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v2.25.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Apollo",
       "email": "opensource@apollographql.com"
@@ -169,6 +169,18 @@
       "licenseUrl": "https://github.com/prettier/prettier/blob/v2.3.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "James Long"
+    },
+    "sinon@11.1.2": {
+      "name": "sinon",
+      "version": "11.1.2",
+      "range": "^11.1.2",
+      "licenses": "BSD-3-Clause",
+      "repoUrl": "https://github.com/sinonjs/sinon",
+      "versionedRepoUrl": "https://github.com/sinonjs/sinon/tree/v11.1.2",
+      "licenseFile": "node_modules/sinon/LICENSE",
+      "licenseUrl": "https://github.com/sinonjs/sinon/blob/v11.1.2/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Christian Johansen"
     },
     "tap@15.0.6": {
       "name": "tap",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Limited `apollo-server-koa` versions in versioned tests to skip testing versions that have a hard-pinned `koa` peer-dependency.

* Limited `@apollo/gateway` versions <0.41 in versioned tests to avoid parse errors that are occurring with newer versions.

## Links

* Should solve test failures unrelated to change in this PR: https://github.com/newrelic/newrelic-node-apollo-server-plugin/pull/134

## Details

**NOTE:** I am unsure of the root cause of the gateway version breakages. This could be in our setup or a bug in gateway. If we track down a bug in gateway and there isn't an issue, we should submit one.

Also defaulted `npm run versioned` to run the npm7+ style since we are mostly locally developing using Node16 these days.

Finally, appears to have added a third part notice for sinon which has nothing to do with these changes / must have been missed in previous changes.