### PR TITLE
Fixes apollo-server version testing 

### DIFF
--- a/tests/integration/apollo-server-setup.js
+++ b/tests/integration/apollo-server-setup.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const createApolloServerSetup = require('../create-apollo-server-setup')
+
+const setupApolloServerTests = createApolloServerSetup(loadApolloServer, clearCachedModules)
+
+// Required to load modules starting from this folder.
+function loadApolloServer() {
+  return require('apollo-server')
+}
+
+// Required to delete modules from same location.
+function clearCachedModules(modules) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+}
+
+module.exports = {
+  setupApolloServerTests
+}

--- a/tests/integration/config-capture-introspection-queries.test.js
+++ b/tests/integration/config-capture-introspection-queries.test.js
@@ -7,7 +7,7 @@
 
 const { executeQuery } = require('../test-client')
 const { setupEnvConfig } = require('../agent-testing')
-const { setupApolloServerTests } = require('../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 const queries = [
   `{
     __schema {

--- a/tests/integration/config-capture-scalars.test.js
+++ b/tests/integration/config-capture-scalars.test.js
@@ -12,7 +12,7 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 const TRANSACTION_PREFIX = 'WebTransaction/Expressjs/POST'
 
-const { setupApolloServerTests } = require('../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 
 setupApolloServerTests({
   suiteName: 'default',

--- a/tests/integration/metrics.test.js
+++ b/tests/integration/metrics.test.js
@@ -15,7 +15,7 @@ const UNKNOWN_OPERATION = '<unknown>'
 const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
-const { setupApolloServerTests } = require('../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 
 setupApolloServerTests({
   suiteName: 'metrics',

--- a/tests/integration/state-loss.test.js
+++ b/tests/integration/state-loss.test.js
@@ -8,7 +8,7 @@
 const { executeQuery } = require('../test-client')
 const { setupEnvConfig } = require('../agent-testing')
 
-const { setupApolloServerTests } = require('../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 
 const PluginStateLossTester = require('./plugin-state-loss-tester')
 const stateLossTester = new PluginStateLossTester()

--- a/tests/versioned/apollo-server/apollo-server-setup.js
+++ b/tests/versioned/apollo-server/apollo-server-setup.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const createApolloServerSetup = require('../../create-apollo-server-setup')
+
+const setupApolloServerTests = createApolloServerSetup(loadApolloServer, clearCachedModules)
+
+// Required to load modules starting from this folder.
+// This is important so that versioned testing uses version permutations not the  dev dependency version.
+function loadApolloServer() {
+  return require('apollo-server')
+}
+
+// Required to delete modules from same location.
+function clearCachedModules(modules) {
+  modules.forEach((moduleName) => {
+    const requirePath = require.resolve(moduleName)
+    delete require.cache[requirePath]
+  })
+}
+
+module.exports = {
+  setupApolloServerTests
+}

--- a/tests/versioned/apollo-server/attributes.test.js
+++ b/tests/versioned/apollo-server/attributes.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { setupApolloServerTests } = require('../../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 const attributesTests = require('../attributes-tests')
 
 setupApolloServerTests(attributesTests)

--- a/tests/versioned/apollo-server/errors.test.js
+++ b/tests/versioned/apollo-server/errors.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { setupApolloServerTests } = require('../../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 const errorsTests = require('../errors-tests')
 
 setupApolloServerTests(errorsTests, {

--- a/tests/versioned/apollo-server/query-obfuscation.test.js
+++ b/tests/versioned/apollo-server/query-obfuscation.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { setupApolloServerTests } = require('../../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 const queryObfuscationTests = require('../query-obfuscation-tests')
 
 setupApolloServerTests(queryObfuscationTests)

--- a/tests/versioned/apollo-server/segments.test.js
+++ b/tests/versioned/apollo-server/segments.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { setupApolloServerTests } = require('../../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 const expressSegmentsDefaultTests = require('../express-segments-default-tests')
 const expressSegmentsScalarTests = require('../express-segments-scalar-tests')
 

--- a/tests/versioned/apollo-server/transaction-naming.test.js
+++ b/tests/versioned/apollo-server/transaction-naming.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const { setupApolloServerTests } = require('../../apollo-server-setup')
+const { setupApolloServerTests } = require('./apollo-server-setup')
 const transactionNamingTests = require('../transaction-naming-tests')
 
 setupApolloServerTests(transactionNamingTests)

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -11,7 +11,7 @@ const { checkResult } = require('./common')
 const ANON_PLACEHOLDER = '<anonymous>'
 
 /**
- * Creates a set of standard transction tests to run against various
+ * Creates a set of standard transaction tests to run against various
  * apollo-server libraries.
  * It is required that t.context.helper and t.context.serverUrl are set.
  * @param {*} t a tap test instance


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed apollo-server test setup so that the apollo-server specific versioned tests accurately test the right versions.

## Links

* Fixes: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/136

## Details

There may be a better way to pull this off but was running low on brainpower.

Essentially, the module imports need to happen within the context of the folder under test or they will walk up to the base set of modules instead of the versioned test folder's modules. When doing that, it only ever tests one version of apollo-server. If we didn't have apollo-server as a dev-dep, it would fail to install at all.

For now, this modified the setup to return a setup function and then the integration tests and the versioned tests pass in functions to load/clean-up dependencies. This way they are loaded from the correct locations. Its not super straightforward but didn't seem to be super confusing. We could also duplicate the setup as having two copies isn't all that bad but I think this is still easy enough to follow.

Also open to other suggestions.