### PR TITLE
Updates federation testing to always use latest 

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -32,6 +32,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 * [prettier](#prettier)
 * [sinon](#sinon)
 * [tap](#tap)
+* [tsd](#tsd)
 
 
 ## dependencies
@@ -458,7 +459,7 @@ This product includes source derived from [@newrelic/newrelic-oss-cli](https://g
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v5.1.0](https://github.com/newrelic/node-test-utilities/tree/v5.1.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v5.1.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.1.1](https://github.com/newrelic/node-test-utilities/tree/v6.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE):
 
 ```
                                  Apache License
@@ -667,7 +668,7 @@ This product includes source derived from [@newrelic/test-utilities](https://git
 
 ### apollo-server
 
-This product includes source derived from [apollo-server](https://github.com/apollographql/apollo-server) ([v2.25.2](https://github.com/apollographql/apollo-server/tree/v2.25.2)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v2.25.2/LICENSE):
+This product includes source derived from [apollo-server](https://github.com/apollographql/apollo-server) ([v2.18.2](https://github.com/apollographql/apollo-server/tree/v2.18.2)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v2.18.2/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -1164,6 +1165,23 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+```
+
+### tsd
+
+This product includes source derived from [tsd](https://github.com/SamVerschueren/tsd) ([v0.18.0](https://github.com/SamVerschueren/tsd/tree/v0.18.0)), distributed under the [MIT License](https://github.com/SamVerschueren/tsd/blob/v0.18.0/license):
+
+```
+MIT License
+
+Copyright (c) Sam Verschueren <sam.verschueren@gmail.com> (github.com/SamVerschueren)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@newrelic/eslint-config": "^0.0.2",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
-        "@newrelic/test-utilities": "^5.1.0",
+        "@newrelic/test-utilities": "^6.1.1",
         "apollo-server": "^2.18.2",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
@@ -747,9 +747,9 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-5.1.0.tgz",
-      "integrity": "sha512-Z4W27G/ivPIVKA42liIQhnicuqA2Tqw62gkE2/tb92yZpZlyVLswqOovfM7/3vG3GuXJJ/mnceVMJYIC1MzRmw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
+      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
       "dev": true,
       "dependencies": {
         "async": "^2.6.0",
@@ -765,7 +765,7 @@
         "versioned-tests": "bin/version-manager.js"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/@newrelic/test-utilities/node_modules/async": {
@@ -12718,9 +12718,9 @@
       }
     },
     "@newrelic/test-utilities": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-5.1.0.tgz",
-      "integrity": "sha512-Z4W27G/ivPIVKA42liIQhnicuqA2Tqw62gkE2/tb92yZpZlyVLswqOovfM7/3vG3GuXJJ/mnceVMJYIC1MzRmw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
+      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@newrelic/eslint-config": "^0.0.2",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
-    "@newrelic/test-utilities": "^5.1.0",
+    "@newrelic/test-utilities": "^6.1.1",
     "apollo-server": "^2.18.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
@@ -55,8 +55,8 @@
     "tsd": "^0.18.0"
   },
   "peerDependencies": {
-    "newrelic": ">=6.13.0",
-    "apollo-server-plugin-base": ">=0.10.1"
+    "apollo-server-plugin-base": ">=0.10.1",
+    "newrelic": ">=6.13.0"
   },
   "tsd": {
     "directory": "./tests/types",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "type-check": "tsd",
     "versioned": "npm run versioned:npm7",
     "versioned:folder": "versioned-tests --minor -i 2",
-    "versioned:npm6": "versioned-tests --minor -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
-    "versioned:npm7": "versioned-tests --minor --all -i 2 'tests/versioned/*'"
+    "versioned:npm6": "versioned-tests --minor --samples 15 -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
+    "versioned:npm7": "versioned-tests --minor --all --samples 15 -i 2 'tests/versioned/*'"
   },
   "files": [
     "index.js",

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -16,8 +16,8 @@
         "@apollo/federation": "latest",
         "@apollo/gateway": "latest",
         "@opentelemetry/api": "latest",
-        "apollo-server": "latest"
-
+        "apollo-server": "latest",
+        "graphql": "latest"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -2,19 +2,22 @@
   "name": "apollo-server-tests",
   "version": "0.0.0",
   "private": true,
+  "//": [
+    "TODO: this is using latest as federation/gateway are not yet >=1.0 and ship with",
+    "breaking changes. Some versions of gateway do not play well with federation.",
+    "Update to proper version testing as federation and gateway modules stabilize."
+  ],
   "tests": [
     {
       "engines": {
         "node": ">=12.13.0"
       },
       "dependencies": {
-        "@apollo/federation": ">=0.25.2",
-        "@apollo/gateway": {
-          "versions": ">=0.31.0 <0.41",
-          "samples": 3
-        },
-        "@opentelemetry/api": "1.0.1",
-        "apollo-server": "2.25.1"
+        "@apollo/federation": "latest",
+        "@apollo/gateway": "latest",
+        "@opentelemetry/api": "latest",
+        "apollo-server": "latest"
+
       },
       "files": [
         "segments.test.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Oct 13 2021 16:45:37 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Wed Oct 20 2021 11:25:01 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -32,28 +32,28 @@
       "licenseTextSource": "file",
       "publisher": "New Relic"
     },
-    "@newrelic/test-utilities@5.1.0": {
+    "@newrelic/test-utilities@6.1.1": {
       "name": "@newrelic/test-utilities",
-      "version": "5.1.0",
-      "range": "^5.1.0",
+      "version": "6.1.1",
+      "range": "^6.1.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v5.1.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.1.1",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v5.1.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "apollo-server@2.25.2": {
+    "apollo-server@2.18.2": {
       "name": "apollo-server",
-      "version": "2.25.2",
+      "version": "2.18.2",
       "range": "^2.18.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/apollographql/apollo-server",
-      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v2.25.2",
+      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v2.18.2",
       "licenseFile": "node_modules/apollo-server/LICENSE",
-      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v2.25.2/LICENSE",
+      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v2.18.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Apollo",
       "email": "opensource@apollographql.com"
@@ -195,6 +195,20 @@
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",
       "url": "http://blog.izs.me"
+    },
+    "tsd@0.18.0": {
+      "name": "tsd",
+      "version": "0.18.0",
+      "range": "^0.18.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/SamVerschueren/tsd",
+      "versionedRepoUrl": "https://github.com/SamVerschueren/tsd/tree/v0.18.0",
+      "licenseFile": "node_modules/tsd/license",
+      "licenseUrl": "https://github.com/SamVerschueren/tsd/blob/v0.18.0/license",
+      "licenseTextSource": "file",
+      "publisher": "Sam Verschueren",
+      "email": "sam.verschueren@gmail.com",
+      "url": "https://github.com/SamVerschueren"
     }
   }
 }

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Oct 20 2021 11:25:01 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Wed Oct 20 2021 12:35:48 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped `@newrelic/test-utilities` to ^6.1.1.

* Updated apollo-federation versioned tests to always test against latest dependency versions.

  Federated gateway modules are al < 1.0 releases and have incompatibilities with each other at various versions that impact our versioned testing. We now test only the latest pairs while these are in flight and may have various breaking changes. Once these go 1.0+, we can switch back to a permutation approach.

* Added `graphql` as a test dependency for apollo-federation versioned tests to fix issues on Node 12/14 runs.

* Limited samples to 15 for full versioned test runs to limit permutations as more versions are released.

## Links

* Fixes: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/138

## Details

Looks like the TSD dep didn't update the notices previously for some reason so that got auto-jammed in here along with updating the test utils.

I'm guessing we'll eventually need `graphql` set for each of our test folders as it is a peer dependency but keeping this PR focused on resolving the federation test issues that currently exist.