### PR TITLE
Export createPlugin function by default on TS definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,4 @@ export type NRPluginConfig = {
   captureHealthCheckQueries?: boolean;
 };
 
-declare let NRApolloPlugin: ApolloServerPlugin;
-
-export function createPlugin(config: NRPluginConfig): ApolloServerPlugin;
-
-export default NRApolloPlugin;
+export default function createPlugin(config: NRPluginConfig): ApolloServerPlugin;

--- a/tests/types/index.test-d.ts
+++ b/tests/types/index.test-d.ts
@@ -1,9 +1,7 @@
 import { ApolloServerPlugin } from "apollo-server-plugin-base";
-import { expectType, expectAssignable } from "tsd";
+import { expectType } from "tsd";
 
-import NRApolloPlugin, { createPlugin } from "../..";
-
-expectAssignable<ApolloServerPlugin>(NRApolloPlugin);
+import createPlugin from "../..";
 
 expectType<ApolloServerPlugin>(createPlugin({}));
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

- Update TypeScript definitions to export `createPlugin` function by default instead of a plugin instance

## Links

* Fixes #144 

## Details

This definition allows us to use the plugin function as follows:

```typescript
import createNewRelicApolloPlugin from '@newrelic/apollo-server-plugin'

@Module({
  imports: [
    GraphQLModule.forRoot({
      plugins: [
        createNewRelicApolloPlugin({}),
      ],
    }),
   // ...
```

With the current definitions, it's not possible to invoke the `createPlugin` function as needed, as the default export only refers to an instance.