### PR TITLE
Fix federation test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "unit": "tap --test-regex='(\\/|^tests\\/unit\\/.*\\.test\\.js)$' --no-coverage",
     "type-check": "tsd",
     "versioned": "npm run versioned:npm7",
-    "versioned:folder": "versioned-tests --minor -i 2",
+    "versioned:folder": "versioned-tests --minor --all -i 2",
     "versioned:npm6": "versioned-tests --minor --samples 15 -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
     "versioned:npm7": "versioned-tests --minor --all --samples 15 -i 2 'tests/versioned/*'"
   },

--- a/tests/versioned/apollo-federation/federated-gateway-server-setup.js
+++ b/tests/versioned/apollo-federation/federated-gateway-server-setup.js
@@ -144,6 +144,7 @@ async function loadServer(ApolloServer, config, plugins) {
 
   const { name, typeDefs, resolvers } = config
 
+  // TODO: (node:8785) DeprecationWarning: 'buildFederatedSchema' is deprecated. Use 'buildSubgraphSchema' instead.
   const server = new ApolloServer({
     schema: buildFederatedSchema([{ typeDefs, resolvers }]),
     plugins

--- a/tests/versioned/apollo-federation/federated-gateway-server-setup.js
+++ b/tests/versioned/apollo-federation/federated-gateway-server-setup.js
@@ -140,13 +140,12 @@ async function loadMagazines({ ApolloServer, gql }, plugins) {
 }
 
 async function loadServer(ApolloServer, config, plugins) {
-  const { buildFederatedSchema } = require('@apollo/federation')
+  const { buildSubgraphSchema } = require('@apollo/federation')
 
   const { name, typeDefs, resolvers } = config
 
-  // TODO: (node:8785) DeprecationWarning: 'buildFederatedSchema' is deprecated. Use 'buildSubgraphSchema' instead.
   const server = new ApolloServer({
-    schema: buildFederatedSchema([{ typeDefs, resolvers }]),
+    schema: buildSubgraphSchema([{ typeDefs, resolvers }]),
     plugins
   })
 

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -17,7 +17,7 @@
         "@apollo/gateway": "latest",
         "@opentelemetry/api": "latest",
         "apollo-server": "latest",
-        "graphql": "latest"
+        "graphql": "15.7.2"
       },
       "files": [
         "segments.test.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Oct 20 2021 12:35:48 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Mon Nov 01 2021 10:13:27 GMT-0700 (Pacific Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Pinned `graphql` to a 15.x version for compatibility with Apollo libraries at ^15.

* Updated federation test setup to use `buildSubgraphSchema` per deprecation warnings.

## Links

## Details

Failure looks different locally but crux is that `graphql` now has a v16 and I had this setup to always grab latest.

Noticed a deprecation warning while I was at it and resolved.
