### PR TITLE
README: replace deprecated buildFederatedSchema() method with buildSubbgraphSchema()

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ const server = new ApolloServer({
 
 ```js
 // Sub-Graph server index.js
-const { buildFederatedSchema } = require('@apollo/federation');
+const { buildSubgraphSchema } = require('@apollo/federation');
 const plugin = require('@newrelic/apollo-server-plugin')
 
 const server = new ApolloServer({
-  schema: buildFederatedSchema([{ typeDefs, resolvers }]),
+  schema: buildSubgraphSchema([{ typeDefs, resolvers }]),
   plugins: [ plugin ]
 });
 ```


### PR DESCRIPTION
`buildFederatedSchema` was [deprecated in @apollo/federation v0.28.0](https://www.apollographql.com/docs/federation/api/apollo-subgraph/#buildsubgraphschema) in favor of `buildSubgraphSchema()`.

This updates the README to demonstrate the latest apollo server api.

![image](https://user-images.githubusercontent.com/242797/142935872-da4bb07e-d09d-435d-aeef-afbb6b1302aa.png)
