### PR TITLE
Fix federation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "type-check": "tsd",
     "versioned": "npm run versioned:npm7",
     "versioned:folder": "versioned-tests --minor --all -i 2",
+    "versioned:major": "versioned-tests --major --all -i 2 'tests/versioned/*'",
     "versioned:npm6": "versioned-tests --minor --samples 15 -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
     "versioned:npm7": "versioned-tests --minor --all --samples 15 -i 2 'tests/versioned/*'"
   },

--- a/tests/versioned/apollo-federation/federated-gateway-server-setup.js
+++ b/tests/versioned/apollo-federation/federated-gateway-server-setup.js
@@ -105,9 +105,12 @@ function setupFederatedGatewayServerTests(options, agentConfig) {
 async function loadGateway({ ApolloServer }, services, plugins) {
   const name = 'Gateway'
 
-  const { ApolloGateway } = require('@apollo/gateway')
+  const { ApolloGateway, IntrospectAndCompose } = require('@apollo/gateway')
+
   const gateway = new ApolloGateway({
-    serviceList: services
+    supergraphSdl: new IntrospectAndCompose({
+      subgraphs: services
+    })
   })
 
   const server = new ApolloServer({

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -17,7 +17,7 @@
         "@apollo/gateway": "latest",
         "@opentelemetry/api": "latest",
         "apollo-server": "latest",
-        "graphql": "15.7.2"
+        "graphql": "latest"
       },
       "files": [
         "segments.test.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Nov 11 2021 16:05:25 GMT-0800 (Pacific Standard Time)",
+  "lastUpdated": "Mon Feb 07 2022 10:21:29 GMT-0800 (Pacific Standard Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated federation versioned tests to only use latest version of `graphql` to avoid incompatibility failures while federation/gateway are still unstable.

* Updated ApolloGateway test setup to use IntrospectAndClose instead of deprecated serviceList.

## Links

## Details
The latest version of the `@apollo/federation` 0.34.0 removed support for graphql 15 which broke our versioned tests: https://github.com/apollographql/federation/pull/1472
