### PR TITLE
Adds graqhql to versioned test dependencies

### DIFF
--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -9,7 +9,8 @@
       },
       "dependencies": {
         "apollo-server-express": ">=2.14.0",
-        "express": "4.17.1"
+        "express": "4.17.1",
+        "graphql": "15.8.0"
       },
       "files": [
         "transaction-naming.test.js",

--- a/tests/versioned/apollo-server-fastify/package.json
+++ b/tests/versioned/apollo-server-fastify/package.json
@@ -9,7 +9,8 @@
       },
       "dependencies": {
         "apollo-server-fastify": ">=2.14.0",
-        "fastify": "3.17.0"
+        "fastify": "3.17.0",
+        "graphql": "15.8.0"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-server-hapi/package.json
+++ b/tests/versioned/apollo-server-hapi/package.json
@@ -9,7 +9,8 @@
       },
       "dependencies": {
         "apollo-server-hapi": ">=2.14.0",
-        "@hapi/hapi": "18.4.1"
+        "@hapi/hapi": "18.4.1",
+        "graphql": "15.8.0"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-server-koa/package.json
+++ b/tests/versioned/apollo-server-koa/package.json
@@ -9,7 +9,8 @@
       },
       "dependencies": {
         "apollo-server-koa": ">=2.14.0 <3.0.2",
-        "koa": ">=2.13.0"
+        "koa": ">=2.13.0",
+        "graphql": "15.8.0"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-server-lambda/package.json
+++ b/tests/versioned/apollo-server-lambda/package.json
@@ -8,7 +8,8 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-lambda": ">=2.14.0"
+        "apollo-server-lambda": ">=2.14.0",
+        "graphql": "15.8.0"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -8,7 +8,8 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server": ">=2.14.0"
+        "apollo-server": ">=2.14.0",
+        "graphql": "15.8.0"
       },
       "files": [
         "transaction-naming.test.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added `graqhql` as a test dependency in the versioned test `package.json` configurations.

## Links

## Details

`graphql` is a peer dependency and is not automatically installed in Node 14 or earlier (older npm versions). When running tests directly within the repo, module loading falls back to the version of `graphql` installed in the dev dependencies. When running within the main agent, there's no dependency to fall back to as it runs the tests just with the configured test dependencies.

Using 15 instead of latest as 16 has some breaking changes.

This *should* resolve current issues with: https://github.com/newrelic/node-newrelic/pull/1110
