### PR TITLE
added support for fragment definitions before query

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -263,8 +263,19 @@ function isTopLevelField(fieldInfo) {
   return result
 }
 
+/**
+ * fragments could be defined for a given operation.  This iterates over the definitions
+ * to find the operation definition to avoid issues with naming
+ * see: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/175
+ *
+ * @param {Array} definitions
+ */
+function findOperationDefinition(definitions) {
+  return definitions.find((definition) => definition.kind === 'OperationDefinition')
+}
+
 function getDetailsFromDocument(responseContext) {
-  const [definition] = responseContext.document.definitions
+  const definition = findOperationDefinition(responseContext.document.definitions)
 
   const pathAndArgs = getDeepestPathAndQueryArguments(definition)
 

--- a/tests/integration/metrics.test.js
+++ b/tests/integration/metrics.test.js
@@ -202,4 +202,78 @@ function createMetricsTests(t) {
       t.end()
     })
   })
+
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', () => {
+      const operationPart = `query/${expectedName}/${path}`
+
+      t.metrics([
+        `${OPERATION_PREFIX}/${operationPart}`,
+        `${RESOLVE_PREFIX}/library`,
+        `${RESOLVE_PREFIX}/books`,
+        `${RESOLVE_PREFIX}/author`
+      ])
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', () => {
+      const operationPart = `query/${expectedName}/${path}`
+
+      t.metrics([
+        `${OPERATION_PREFIX}/${operationPart}`,
+        `${RESOLVE_PREFIX}/library`,
+        `${RESOLVE_PREFIX}/books`,
+        `${RESOLVE_PREFIX}/author`
+      ])
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
 }

--- a/tests/unit/create-plugin.test.js
+++ b/tests/unit/create-plugin.test.js
@@ -43,6 +43,7 @@ tap.test('createPlugin edge cases', (t) => {
       document: {
         definitions: [
           {
+            kind: 'OperationDefinition',
             selectionSet: {
               selections: []
             }

--- a/tests/versioned/apollo-server-fastify/segments.test.js
+++ b/tests/versioned/apollo-server-fastify/segments.test.js
@@ -461,6 +461,138 @@ function createFastifySegmentsTests(t, frameworkName) {
     })
   })
 
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: GQL_MIDDLEWARE_SEGMENT_PATTERN,
+              children: [
+                {
+                  name: `${OPERATION_PREFIX}/${operationPart}`,
+                  children: [
+                    {
+                      name: `${RESOLVE_PREFIX}/library`,
+                      children: [
+                        {
+                          name: 'timers.setTimeout',
+                          children: [
+                            {
+                              name: 'Callback: <anonymous>'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    { name: `${RESOLVE_PREFIX}/library.books` },
+                    { name: `${RESOLVE_PREFIX}/library.books.title` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: GQL_MIDDLEWARE_SEGMENT_PATTERN,
+              children: [
+                {
+                  name: `${OPERATION_PREFIX}/${operationPart}`,
+                  children: [
+                    {
+                      name: `${RESOLVE_PREFIX}/library`,
+                      children: [
+                        {
+                          name: 'timers.setTimeout',
+                          children: [
+                            {
+                              name: 'Callback: <anonymous>'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    { name: `${RESOLVE_PREFIX}/library.books` },
+                    { name: `${RESOLVE_PREFIX}/library.books.title` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
   t.test('batch query should include segments for nested queries', (t) => {
     const { helper, serverUrl } = t.context
 

--- a/tests/versioned/apollo-server-hapi/segments.test.js
+++ b/tests/versioned/apollo-server-hapi/segments.test.js
@@ -455,6 +455,138 @@ function createHapiSegmentsTests(t, frameworkName) {
     })
   })
 
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: 'Nodejs/Middleware/Hapi/handler//gql',
+              children: [
+                {
+                  name: `${OPERATION_PREFIX}/${operationPart}`,
+                  children: [
+                    {
+                      name: `${RESOLVE_PREFIX}/library`,
+                      children: [
+                        {
+                          name: 'timers.setTimeout',
+                          children: [
+                            {
+                              name: 'Callback: <anonymous>'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    { name: `${RESOLVE_PREFIX}/library.books` },
+                    { name: `${RESOLVE_PREFIX}/library.books.title` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: 'Nodejs/Middleware/Hapi/handler//gql',
+              children: [
+                {
+                  name: `${OPERATION_PREFIX}/${operationPart}`,
+                  children: [
+                    {
+                      name: `${RESOLVE_PREFIX}/library`,
+                      children: [
+                        {
+                          name: 'timers.setTimeout',
+                          children: [
+                            {
+                              name: 'Callback: <anonymous>'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    { name: `${RESOLVE_PREFIX}/library.books` },
+                    { name: `${RESOLVE_PREFIX}/library.books.title` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
   t.test('batch query should include segments for nested queries', (t) => {
     const { helper, serverUrl } = t.context
 

--- a/tests/versioned/apollo-server-koa/segments.test.js
+++ b/tests/versioned/apollo-server-koa/segments.test.js
@@ -455,6 +455,138 @@ function createKoaSegmentsTests(t, frameworkName) {
     })
   })
 
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: 'Nodejs/Middleware/Koa',
+              children: [
+                {
+                  name: `${OPERATION_PREFIX}/${operationPart}`,
+                  children: [
+                    {
+                      name: `${RESOLVE_PREFIX}/library`,
+                      children: [
+                        {
+                          name: 'timers.setTimeout',
+                          children: [
+                            {
+                              name: 'Callback: <anonymous>'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    { name: `${RESOLVE_PREFIX}/library.books` },
+                    { name: `${RESOLVE_PREFIX}/library.books.title` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: 'Nodejs/Middleware/Koa',
+              children: [
+                {
+                  name: `${OPERATION_PREFIX}/${operationPart}`,
+                  children: [
+                    {
+                      name: `${RESOLVE_PREFIX}/library`,
+                      children: [
+                        {
+                          name: 'timers.setTimeout',
+                          children: [
+                            {
+                              name: 'Callback: <anonymous>'
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    { name: `${RESOLVE_PREFIX}/library.books` },
+                    { name: `${RESOLVE_PREFIX}/library.books.title` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author` },
+                    { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
   t.test('batch query should include segments for nested queries', (t) => {
     const { helper, serverUrl } = t.context
 

--- a/tests/versioned/apollo-server-lambda/segments.test.js
+++ b/tests/versioned/apollo-server-lambda/segments.test.js
@@ -471,6 +471,134 @@ function createLambdaSegmentsTests(t, frameworkName) {
     })
   })
 
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: `${OPERATION_PREFIX}/${operationPart}`,
+              children: [
+                {
+                  name: `${RESOLVE_PREFIX}/library`,
+                  children: [
+                    {
+                      name: 'timers.setTimeout',
+                      children: [
+                        {
+                          name: 'Callback: <anonymous>'
+                        }
+                      ]
+                    }
+                  ]
+                },
+                { name: `${RESOLVE_PREFIX}/library.books` },
+                { name: `${RESOLVE_PREFIX}/library.books.title` },
+                { name: `${RESOLVE_PREFIX}/library.books.author` },
+                { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, patchedHandler, stubContext, modVersion } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: `${OPERATION_PREFIX}/${operationPart}`,
+              children: [
+                {
+                  name: `${RESOLVE_PREFIX}/library`,
+                  children: [
+                    {
+                      name: 'timers.setTimeout',
+                      children: [
+                        {
+                          name: 'Callback: <anonymous>'
+                        }
+                      ]
+                    }
+                  ]
+                },
+                { name: `${RESOLVE_PREFIX}/library.books` },
+                { name: `${RESOLVE_PREFIX}/library.books.title` },
+                { name: `${RESOLVE_PREFIX}/library.books.author` },
+                { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQueryAssertResult({
+      handler: patchedHandler,
+      query,
+      context: stubContext,
+      t,
+      modVersion
+    })
+  })
+
   t.test('batch query should include segments for nested queries', (t) => {
     const { helper, patchedHandler, stubContext, modVersion } = t.context
 

--- a/tests/versioned/express-segments-scalar-tests.js
+++ b/tests/versioned/express-segments-scalar-tests.js
@@ -498,6 +498,148 @@ function createSegmentsTests(t, frameworkName) {
     })
   })
 
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: 'Expressjs/Router: /',
+              children: [
+                {
+                  name: 'Nodejs/Middleware/Expressjs/<anonymous>',
+                  children: [
+                    {
+                      name: `${OPERATION_PREFIX}/${operationPart}`,
+                      children: [
+                        {
+                          name: `${RESOLVE_PREFIX}/library`,
+                          children: [
+                            {
+                              name: 'timers.setTimeout',
+                              children: [
+                                {
+                                  name: 'Callback: <anonymous>'
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        { name: `${RESOLVE_PREFIX}/library.books` },
+                        { name: `${RESOLVE_PREFIX}/library.books.title` },
+                        { name: `${RESOLVE_PREFIX}/library.books.author` },
+                        { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationPart = `query/${expectedName}/${path}`
+      const expectedSegments = [
+        {
+          name: `${TRANSACTION_PREFIX}//${operationPart}`,
+          children: [
+            {
+              name: 'Expressjs/Router: /',
+              children: [
+                {
+                  name: 'Nodejs/Middleware/Expressjs/<anonymous>',
+                  children: [
+                    {
+                      name: `${OPERATION_PREFIX}/${operationPart}`,
+                      children: [
+                        {
+                          name: `${RESOLVE_PREFIX}/library`,
+                          children: [
+                            {
+                              name: 'timers.setTimeout',
+                              children: [
+                                {
+                                  name: 'Callback: <anonymous>'
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        { name: `${RESOLVE_PREFIX}/library.books` },
+                        { name: `${RESOLVE_PREFIX}/library.books.title` },
+                        { name: `${RESOLVE_PREFIX}/library.books.author` },
+                        { name: `${RESOLVE_PREFIX}/library.books.author.name` }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+
+      t.segments(transaction.trace.root, expectedSegments)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
   t.test('batch query should include segments for nested queries', (t) => {
     const { helper, serverUrl } = t.context
 

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -420,6 +420,66 @@ function createTransactionTests(t, frameworkName) {
     })
   })
 
+  t.test('named query with fragment, query first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }
+    fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//query/${expectedName}/${path}`)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
+  t.test('named query with fragment, fragment first', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'GetBookForLibrary'
+    const query = `fragment LibraryBook on Book {
+      title
+      author {
+        name
+      }
+    }
+    query ${expectedName} {
+      library(branch: "downtown") {
+        books {
+          ... LibraryBook
+        }
+      }
+    }`
+
+    const path = 'library.books.LibraryBook'
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//query/${expectedName}/${path}`)
+    })
+
+    executeQuery(serverUrl, query, (err) => {
+      t.error(err)
+      t.end()
+    })
+  })
+
   // there will be no document/AST nor resolved operation
   t.test('if the query cannot be parsed, should be named /*', (t) => {
     const { helper, serverUrl } = t.context


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed transaction naming and operation segments when a fragment is defined before query.

## Links
Closes #175

## Details
We operated on the assumption before that the operation definition was always first in a document.  This PR fixes that by finding the operation segment within a document.  It also adds two test cases that prove the fix works.  The one test where the fragment was after query always worked but the one where the fragment was first failed.
