### PR TITLE
updated transaction names to sub graphs in federation tests

### DIFF
--- a/tests/versioned/apollo-federation/sub-graph-transactions.test.js
+++ b/tests/versioned/apollo-federation/sub-graph-transactions.test.js
@@ -70,10 +70,10 @@ function createFederatedSegmentsTests(t) {
 
     let transactions = []
     const expectedTransactions = [
-      'WebTransaction/Expressjs/POST//query/<anonymous>/libraries.branch',
-      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities<Library>.booksInStock',
+      'WebTransaction/Expressjs/POST//query/SubGraphs__Library__0/libraries.branch',
+      'WebTransaction/Expressjs/POST//query/SubGraphs__Book__1/_entities<Library>.booksInStock',
       // eslint-disable-next-line max-len
-      'WebTransaction/Expressjs/POST//query/<anonymous>/_entities<Library>.magazinesInStock',
+      'WebTransaction/Expressjs/POST//query/SubGraphs__Magazine__2/_entities<Library>.magazinesInStock',
       'WebTransaction/Expressjs/POST//query/SubGraphs/libraries'
     ]
 
@@ -125,7 +125,7 @@ function createFederatedSegmentsTests(t) {
 
     let transactions = []
     const expectedPath = 'libraries.branch'
-    const expectedTransaction = `WebTransaction/Expressjs/POST//query/<anonymous>/${expectedPath}`
+    const expectedTransaction = `WebTransaction/Expressjs/POST//query/SubGraphs__Library__0/${expectedPath}`
 
     helper.agent.on('transactionFinished', (transaction) => {
       transactions.push(transaction.name)


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated expected names for transaction in federated versioned tests.

## Links

## Details
Although I can't track it down, it appears `@apollo/gateway` or ``@apollo/federation` added more metadata to queries made to subgraphs.  It now adds the query name then the subgraph name and some numberic value representing when the subgraph was registed.

So previously you would see `/WebTransaction/Expressjs/POST//query/<anonymous>/libraries.books` now that looks like `/WebTransaction/Expressjs/POST//query/SubGraph__Library__0/libraries.books`.
