### PR TITLE
Name operation segment earlier

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -12,13 +12,14 @@ const cleanQuery = require('./query-utils')
 const NOTICED_ERRORS = ErrorHelper.NOTICED_ERRORS
 
 const ANON_PLACEHOLDER = '<anonymous>'
-const UNKNOWN_OPERATION = '<unknown>'
 
 const CATEGORY = 'GraphQL'
 const FRAMEWORK = 'ApolloServer'
 const OPERATION_PREFIX = CATEGORY + '/operation/' + FRAMEWORK
 const RESOLVE_PREFIX = CATEGORY + '/resolve/' + FRAMEWORK
 const BATCH_PREFIX = 'batch'
+
+const DEFAULT_OPERATION_NAME = `${OPERATION_PREFIX}/<unknown>`
 
 const FIELD_NAME_ATTR = 'graphql.field.name'
 const RETURN_TYPE_ATTR = 'graphql.field.returnType'
@@ -86,7 +87,7 @@ function createPlugin(instrumentationApi, config = {}) {
       // We do not set to active here as batched queries will hit this
       // back to back and we'd prefer those not nest with each-other.
       const operationSegment = instrumentationApi.createSegment(
-        UNKNOWN_OPERATION,
+        DEFAULT_OPERATION_NAME,
         recordOperationSegment,
         requestParent
       )
@@ -99,6 +100,38 @@ function createPlugin(instrumentationApi, config = {}) {
       operationSegment.start()
 
       return {
+        /**
+         * The document AST has been parsed so we can attempt to name the operation
+         * and update the transaction name based on operation
+         */
+        validationDidStart(validationContext) {
+          const operationDetails = getOperationDetails(validationContext)
+          if (operationDetails) {
+            const { operationName, operationType, deepestUniquePath, cleanedQuery } =
+              operationDetails
+
+            operationSegment.addAttribute(OPERATION_QUERY_ATTR, cleanedQuery)
+
+            operationSegment.addAttribute(OPERATION_TYPE_ATTR, operationType)
+
+            if (operationName) {
+              operationSegment.addAttribute(OPERATION_NAME_ATTR, operationName)
+            }
+
+            const formattedName = operationName || ANON_PLACEHOLDER
+            let formattedOperation = `${operationType}/${formattedName}`
+
+            // Certain requests, such as introspection, won't hit any resolvers
+            if (deepestUniquePath) {
+              formattedOperation += `/${deepestUniquePath}`
+            }
+
+            const segmentName = formattedOperation
+            const transactionName = formattedOperation
+            setTransactionName(operationSegment.transaction, transactionName)
+            operationSegment.name = `${OPERATION_PREFIX}/${segmentName}`
+          }
+        },
         didResolveOperation(resolveContext) {
           if (shouldIgnoreTransaction(resolveContext.operation, config, logger)) {
             const activeSegment = instrumentationApi.getActiveSegment()
@@ -184,39 +217,12 @@ function createPlugin(instrumentationApi, config = {}) {
             }
           }
         },
-        willSendResponse(responseContext) {
-          // default. only used if failed to parse
-          let transactionName = '*'
-          let segmentName = UNKNOWN_OPERATION
-
-          const operationDetails = getOperationDetails(responseContext)
-          if (operationDetails) {
-            const { operationName, operationType, deepestUniquePath, cleanedQuery } =
-              operationDetails
-
-            operationSegment.addAttribute(OPERATION_QUERY_ATTR, cleanedQuery)
-
-            operationSegment.addAttribute(OPERATION_TYPE_ATTR, operationType)
-
-            if (operationName) {
-              operationSegment.addAttribute(OPERATION_NAME_ATTR, operationName)
-            }
-
-            const formattedName = operationName || ANON_PLACEHOLDER
-            let formattedOperation = `${operationType}/${formattedName}`
-
-            // Certain requests, such as introspection, won't hit any resolvers
-            if (deepestUniquePath) {
-              formattedOperation += `/${deepestUniquePath}`
-            }
-
-            segmentName = formattedOperation
-            transactionName = formattedOperation
+        willSendResponse() {
+          // check if operation segment was never updated from default name
+          // If so, update the transaction name to `*`
+          if (operationSegment.name === DEFAULT_OPERATION_NAME) {
+            setTransactionName(operationSegment.transaction, '*')
           }
-
-          setTransactionName(operationSegment.transaction, transactionName)
-
-          operationSegment.name = `${OPERATION_PREFIX}/${segmentName}`
           operationSegment.end()
 
           logger.trace('End willSendResponse')

--- a/tests/unit/create-plugin.test.js
+++ b/tests/unit/create-plugin.test.js
@@ -54,7 +54,7 @@ tap.test('createPlugin edge cases', (t) => {
 
     const hooks = createPlugin(instrumentationApi)
     const operationHooks = hooks.requestDidStart({})
-    operationHooks.willSendResponse(responseContext)
+    operationHooks.validationDidStart(responseContext)
     t.equal(
       operationSegment.name,
       'GraphQL/operation/ApolloServer/undefined/<anonymous>',
@@ -63,16 +63,12 @@ tap.test('createPlugin edge cases', (t) => {
     t.end()
   })
 
-  t.test('should not set operation name to unknown when document is null', (t) => {
+  t.test('should not set operation name when document is null', (t) => {
     const responseContext = {}
     const hooks = createPlugin(instrumentationApi)
     const operationHooks = hooks.requestDidStart({})
     operationHooks.willSendResponse(responseContext)
-    t.equal(
-      operationSegment.name,
-      'GraphQL/operation/ApolloServer/<unknown>',
-      'should set operation to unknown'
-    )
+    t.equal(operationSegment.name, undefined, 'should set operation to unknown')
     t.end()
   })
 })

--- a/tests/unit/create-plugin.test.js
+++ b/tests/unit/create-plugin.test.js
@@ -33,7 +33,10 @@ tap.test('createPlugin edge cases', (t) => {
         }
       },
       getActiveSegment: sinon.stub().returns({}),
-      createSegment: sinon.stub().returns(operationSegment),
+      createSegment: sinon.stub().callsFake((name) => {
+        operationSegment.name = name
+        return operationSegment
+      }),
       setActiveSegment: sinon.stub()
     }
   })
@@ -63,12 +66,21 @@ tap.test('createPlugin edge cases', (t) => {
     t.end()
   })
 
-  t.test('should not set operation name when document is null', (t) => {
+  t.test('should not update operation name when document is null', (t) => {
     const responseContext = {}
     const hooks = createPlugin(instrumentationApi)
     const operationHooks = hooks.requestDidStart({})
-    operationHooks.willSendResponse(responseContext)
-    t.equal(operationSegment.name, undefined, 'should set operation to unknown')
+    t.equal(
+      operationSegment.name,
+      'GraphQL/operation/ApolloServer/<unknown>',
+      'should default operation name'
+    )
+    operationHooks.validationDidStart(responseContext)
+    t.equal(
+      operationSegment.name,
+      'GraphQL/operation/ApolloServer/<unknown>',
+      'should not update operation name'
+    )
     t.end()
   })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Moved naming of operation segment and updating transaction to `validationDidStart` phase of Apollo Server request.

## Links
Closes #117

## Details
I was able to reproduce the bug #117 by employing the brute force method @carlo-808 mentioned with `connect-timeout`.  So it appears if you initiate an apollo server request but throw some error out of band where apollo does not emit the `didEncounterErrors` hook you get into this situation.  So in the `connect-timeout` case, that middleware will emit a timeout after n milliseconds.  That timeout is not being caught by apollo thus not allowing `didEncounterErrors` and subsequently `willSendResponse` hooks to fire. We were updating the name of the operation segment and transaction in the `willSendResponse`.  There was no reason aside from we had the most information but the only information we need now that we refactored finding the deepest path and naming is from the graphql document AST.  The first time this is available is in `validationDidStart`, hence the PR.

