### PR TITLE
Fixed mutation naming

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -412,6 +412,7 @@ function getDeepestPathAndQueryArguments(definition) {
       // When no selections returned from filtering, deepest path is found
       if (filtered.length === 0 || filtered.length > 1) {
         foundDeepestPath = true
+        deepestPath = parts
       }
 
       // Recurse through inner selections

--- a/tests/data-definitions.js
+++ b/tests/data-definitions.js
@@ -63,6 +63,8 @@ const magazines = [
   }
 ]
 
+const collection = []
+
 function getTypeDefs(gql) {
   const typeDefs = gql`
     union SearchResult = Book | Magazine
@@ -103,8 +105,14 @@ function getTypeDefs(gql) {
       library(branch: String!): Library
     }
 
+    type Collection {
+      "concat string"
+      id: String!
+    }
+
     type Mutation {
       addThing(name: String!): String!
+      addToCollection(title: String!): Collection!
     }
   `
   return typeDefs
@@ -146,6 +154,12 @@ const resolvers = {
       })
       const result = await promise
       return result
+    },
+    addToCollection: async (_, { title }) => {
+      return await new Promise((resolve) => {
+        collection.push({ id: title })
+        resolve({ id: title })
+      })
     }
   },
   Library: {

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -194,6 +194,33 @@ function createTransactionTests(t, frameworkName) {
     })
   })
 
+  t.test(
+    'anonymous mutation, single level, reserved field, should use anonymous placeholder',
+    (t) => {
+      const { helper, serverUrl } = t.context
+
+      const query = `mutation {
+      addToCollection(title: "Don Quixote") {
+        id
+      }
+    }`
+
+      helper.agent.on('transactionFinished', (transaction) => {
+        t.equal(
+          transaction.name,
+          `${EXPECTED_PREFIX}//mutation/${ANON_PLACEHOLDER}/addToCollection`
+        )
+      })
+
+      executeQuery(serverUrl, query, (err, result) => {
+        t.error(err)
+        checkResult(t, result, () => {
+          t.end()
+        })
+      })
+    }
+  )
+
   t.test('anonymous mutation, single level, should use anonymous placeholder', (t) => {
     const { helper, serverUrl } = t.context
 
@@ -203,6 +230,28 @@ function createTransactionTests(t, frameworkName) {
 
     helper.agent.on('transactionFinished', (transaction) => {
       t.equal(transaction.name, `${EXPECTED_PREFIX}//mutation/${ANON_PLACEHOLDER}/addThing`)
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        t.end()
+      })
+    })
+  })
+
+  t.test('named mutation, single level, reserved field, should use mutation name', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'addIt'
+    const query = `mutation ${expectedName} {
+      addToCollection(title: "Don Quixote") {
+        id
+      }
+    }`
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//mutation/${expectedName}/addToCollection`)
     })
 
     executeQuery(serverUrl, query, (err, result) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed an issue where a mutation selected only reserved fields and the segment name lacked the mutation name

## Links
Closes #164

## Details
The issue here was there is business logic that iterates over selection sets and if they are all filtered out, we set a flag that we found the deepest path.  However we never assign the parts to the deepest path array.  This woul result in a segment named `/mutation/<anonymous>` and not `/mutation/<anonymous>/<mutation-name>`. I want to test if this is also a scenario for a query, but our schema never had a type with just an ID.
