### PR TITLE
createPlugin: also add the arguments to the operation segment

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -191,14 +191,18 @@ function createPlugin(instrumentationApi, config = {}) {
               resolverSegment.addAttribute(RETURN_TYPE_ATTR, info.returnType.toString())
               resolverSegment.addAttribute(PARENT_TYPE_ATTR, info.parentType.toString())
 
-              for (const [key, value] of Object.entries(args)) {
-                // Require adding to attribute 'include' configuration
-                // so as not to accidentally send senstive info to New Relic.
-                resolverSegment.attributes.addAttribute(
-                  DESTINATIONS.NONE,
-                  `${FIELD_ARGS_ATTR}.${key}`,
-                  value
-                )
+              // For ease of use, we'll add the arguments to both the
+              // resolver and the operation segments.
+              for (const segment of [operationSegment, resolverSegment]) {
+                for (const [key, value] of Object.entries(args)) {
+                  // Require adding to attribute 'include' configuration
+                  // so as not to accidentally send senstive info to New Relic.
+                  segment.attributes.addAttribute(
+                    DESTINATIONS.NONE,
+                    `${FIELD_ARGS_ATTR}.${key}`,
+                    value
+                  )
+                }
               }
 
               return (error) => {

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -191,8 +191,10 @@ function createPlugin(instrumentationApi, config = {}) {
               resolverSegment.addAttribute(RETURN_TYPE_ATTR, info.returnType.toString())
               resolverSegment.addAttribute(PARENT_TYPE_ATTR, info.parentType.toString())
 
-              // For ease of use, we'll add the arguments to both the
-              // resolver and the operation segments.
+              // Like our http and framework instrumentation, we add
+              // the attributes on the operation segment. We also add
+              // the attributes to resolver segments as they help
+              // inform performance impacts.
               for (const segment of [operationSegment, resolverSegment]) {
                 for (const [key, value] of Object.entries(args)) {
                   // Require adding to attribute 'include' configuration

--- a/tests/versioned/apollo-federation/federated-data-definitions.js
+++ b/tests/versioned/apollo-federation/federated-data-definitions.js
@@ -57,7 +57,7 @@ function _getLibraryTypeDef(gql) {
   return typeDefs
 }
 
-// https://www.apollographql.com/docs/federation/api/apollo-federation/#__resolvereference
+// https://www.apollographql.com/docs/federation/api/apollo-subgraph/#__resolvereference
 function _getLibraryResolvers() {
   const resolvers = {
     Library: {

--- a/tests/versioned/apollo-server-lambda/attributes-tests.js
+++ b/tests/versioned/apollo-server-lambda/attributes-tests.js
@@ -370,7 +370,9 @@ function createAttributesTests(t) {
       const resolveHelloSegment = operationSegment.children[0]
 
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
       t.matches(resolveAttributes, { 'graphql.field.args.name': 'added thing!' })
+      t.matches(operationAttributes, { 'graphql.field.args.name': 'added thing!' })
     })
 
     executeQueryAssertResult({
@@ -404,7 +406,9 @@ function createAttributesTests(t) {
         'graphql.field.args.blee': 'second'
       }
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
       t.matches(resolveAttributes, expectedArgAttributes)
+      t.matches(operationAttributes, expectedArgAttributes)
     })
 
     executeQueryAssertResult({
@@ -447,7 +451,9 @@ function createAttributesTests(t) {
         'graphql.field.args.blee': 'second'
       }
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
       t.matches(resolveAttributes, expectedArgAttributes)
+      t.matches(operationAttributes, expectedArgAttributes)
     })
 
     executeQueryJson({

--- a/tests/versioned/attributes-tests.js
+++ b/tests/versioned/attributes-tests.js
@@ -379,7 +379,9 @@ function createAttributesTests(t) {
         'graphql.field.args.blee': 'second'
       }
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
       t.matches(resolveAttributes, expectedArgAttributes)
+      t.matches(operationAttributes, expectedArgAttributes)
     })
 
     executeQuery(serverUrl, query, (err) => {

--- a/tests/versioned/attributes-tests.js
+++ b/tests/versioned/attributes-tests.js
@@ -348,7 +348,9 @@ function createAttributesTests(t) {
       const resolveHelloSegment = operationSegment.children[0]
 
       const resolveAttributes = resolveHelloSegment.attributes.get(SEGMENT_DESTINATION)
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
       t.matches(resolveAttributes, { 'graphql.field.args.name': 'added thing!' })
+      t.matches(operationAttributes, { 'graphql.field.args.name': 'added thing!' })
     })
 
     executeQuery(serverUrl, query, (err) => {


### PR DESCRIPTION
Since it can be confusing for users to see the arguments for the
operation down in the resolve segment, it seems more helpful to
duplicate those arguments in the operation segment's attributes.

## Proposed Release Notes

* also add the arguments to the operation segment

## Links

Closes https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/52