### PR TITLE
Fixed federated tests by making naming assertions less rigid

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -460,7 +460,7 @@ This product includes source derived from [@newrelic/newrelic-oss-cli](https://g
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.1.1](https://github.com/newrelic/node-test-utilities/tree/v6.1.1)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v6.5.2](https://github.com/newrelic/node-test-utilities/tree/v6.5.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v6.5.2/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@newrelic/eslint-config": "^0.0.2",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
-        "@newrelic/test-utilities": "^6.1.1",
+        "@newrelic/test-utilities": "^6.5.2",
         "apollo-server": "^2.18.2",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
@@ -813,16 +813,16 @@
       }
     },
     "node_modules/@newrelic/test-utilities": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
-      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.5.2.tgz",
+      "integrity": "sha512-AgnZshnemighCSYWFszVy7GE6MyLpTafCYaM08SepB5WglH+5i6TfUoZyOf72BEj1AtpcH07BGJrYNH0HPvVog==",
       "dev": true,
       "dependencies": {
         "async": "^2.6.0",
         "colors": "^1.1.2",
         "commander": "^2.14.1",
         "concat-stream": "^1.6.0",
-        "glob": "^7.1.2",
+        "glob": "^7.2.0",
         "lodash": "^4.17.5",
         "log-update": "^1.0.2",
         "semver": "^5.5.0"
@@ -5681,9 +5681,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -12761,16 +12761,16 @@
       "requires": {}
     },
     "@newrelic/test-utilities": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.1.1.tgz",
-      "integrity": "sha512-JTOIqL0ybf1nTpqO5i5JQGdyEp6iXpUwx6YnaO7IKTxbJnnKYOrxaXyq0cRQXeGVv7TxcOXjhOVAO+eJB4C3cw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/test-utilities/-/test-utilities-6.5.2.tgz",
+      "integrity": "sha512-AgnZshnemighCSYWFszVy7GE6MyLpTafCYaM08SepB5WglH+5i6TfUoZyOf72BEj1AtpcH07BGJrYNH0HPvVog==",
       "dev": true,
       "requires": {
         "async": "^2.6.0",
         "colors": "^1.1.2",
         "commander": "^2.14.1",
         "concat-stream": "^1.6.0",
-        "glob": "^7.1.2",
+        "glob": "^7.2.0",
         "lodash": "^4.17.5",
         "log-update": "^1.0.2",
         "semver": "^5.5.0"
@@ -16591,9 +16591,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@newrelic/eslint-config": "^0.0.2",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
-    "@newrelic/test-utilities": "^6.1.1",
+    "@newrelic/test-utilities": "^6.5.2",
     "apollo-server": "^2.18.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",

--- a/tests/versioned/apollo-federation/federated-gateway-server-setup.js
+++ b/tests/versioned/apollo-federation/federated-gateway-server-setup.js
@@ -95,7 +95,7 @@ function setupFederatedGatewayServerTests(options, agentConfig) {
       helper.unload()
       helper = null
 
-      clearCachedModules(['express', 'apollo-server', '@apollo/gateway', '@apollo/federation'])
+      clearCachedModules(['express', 'apollo-server', '@apollo/gateway', '@apollo/subgraph'])
     })
 
     createTests(t, WEB_FRAMEWORK)
@@ -143,7 +143,7 @@ async function loadMagazines({ ApolloServer, gql }, plugins) {
 }
 
 async function loadServer(ApolloServer, config, plugins) {
-  const { buildSubgraphSchema } = require('@apollo/federation')
+  const { buildSubgraphSchema } = require('@apollo/subgraph')
 
   const { name, typeDefs, resolvers } = config
 

--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -13,7 +13,7 @@
         "node": ">=12.13.0"
       },
       "dependencies": {
-        "@apollo/federation": "latest",
+        "@apollo/subgraph": "latest",
         "@apollo/gateway": "latest",
         "@opentelemetry/api": "latest",
         "apollo-server": "latest",

--- a/tests/versioned/apollo-federation/sub-graph-transactions.test.js
+++ b/tests/versioned/apollo-federation/sub-graph-transactions.test.js
@@ -70,11 +70,11 @@ function createFederatedSegmentsTests(t) {
 
     let transactions = []
     const expectedTransactions = [
-      'WebTransaction/Expressjs/POST//query/SubGraphs__Library__0/libraries.branch',
-      'WebTransaction/Expressjs/POST//query/SubGraphs__Book__1/_entities<Library>.booksInStock',
+      /WebTransaction\/Expressjs\/POST\/\/query\/SubGraphs__Library__[\d]+\/libraries.branch/,
+      /WebTransaction\/Expressjs\/POST\/\/query\/SubGraphs__Book__[\d]+\/_entities<Library>.booksInStock/,
       // eslint-disable-next-line max-len
-      'WebTransaction/Expressjs/POST//query/SubGraphs__Magazine__2/_entities<Library>.magazinesInStock',
-      'WebTransaction/Expressjs/POST//query/SubGraphs/libraries'
+      /WebTransaction\/Expressjs\/POST\/\/query\/SubGraphs__Magazine__[\d]+\/_entities<Library>.magazinesInStock/,
+      /WebTransaction\/Expressjs\/POST\/\/query\/SubGraphs\/libraries/
     ]
 
     helper.agent.on('transactionFinished', (transaction) => {
@@ -83,8 +83,13 @@ function createFederatedSegmentsTests(t) {
 
     executeQuery(serverUrl, query, (err, result) => {
       t.equal(transactions.length, 4, 'should create 4 transactions')
+      const transactionMatches = transactions.filter((transaction) => {
+        return expectedTransactions.some((expectedTransaction) =>
+          transaction.match(expectedTransaction)
+        )
+      })
+      t.equal(transactionMatches.length, 4, 'transactions should match proper names')
 
-      t.same(transactions, expectedTransactions, 'should properly name each transaction')
       t.error(err)
       checkResult(t, result, () => {
         t.end()

--- a/tests/versioned/apollo-server-koa/package.json
+++ b/tests/versioned/apollo-server-koa/package.json
@@ -8,8 +8,8 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-koa": ">=2.14.0 <3.0.2",
-        "koa": ">=2.13.0",
+        "apollo-server-koa": ">=2.14.0 <3.4.0",
+        "koa": "2.13.1",
         "graphql": "15.8.0"
       },
       "files": [
@@ -26,7 +26,7 @@
       },
       "dependencies": {
         "apollo-server-koa": ">=3.4.0",
-        "koa": ">=2.13.1"
+        "koa": "^2.13.1"
       },
       "files": [
         "segments.test.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Apr 11 2022 09:38:48 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Thu Apr 14 2022 14:53:30 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -32,15 +32,15 @@
       "licenseTextSource": "file",
       "publisher": "New Relic"
     },
-    "@newrelic/test-utilities@6.1.1": {
+    "@newrelic/test-utilities@6.5.2": {
       "name": "@newrelic/test-utilities",
-      "version": "6.1.1",
-      "range": "^6.1.1",
+      "version": "6.5.2",
+      "range": "^6.5.2",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.1.1",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v6.5.2",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.1.1/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v6.5.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed subgraph transaction tests to be less rigid as the order of transactions vary.
 * Upgraded `@newrelic/test-utilities` to `6.5.2` to take advantage of new features.
 * Swapped out `@apollo/federation` for `@apollo/subgraph` as it is now the recommended package for building sub graph schemas.

## Links

## Details
Builds in agent are failing because of the naming.  [CI Failure](https://github.com/newrelic/node-newrelic/runs/6027906741?check_suite_focus=true)
