### PR TITLE
removed versions of apollo-server-koa that hardcoded koa version as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "versioned": "npm run versioned:npm7",
     "versioned:folder": "versioned-tests --minor --all -i 2",
     "versioned:major": "versioned-tests --major --all -i 2 'tests/versioned/*'",
-    "versioned:npm6": "versioned-tests --minor --samples 15 -i 2 'tests/versioned/**/!(apollo-server-koa)' && versioned-tests --minor --all -i 2 'tests/versioned/apollo-server-koa'",
+    "versioned:npm6": "versioned-tests --minor --samples 15 -i 2 'tests/versioned/*'",
     "versioned:npm7": "versioned-tests --minor --all --samples 15 -i 2 'tests/versioned/*'"
   },
   "files": [

--- a/tests/versioned/apollo-server-koa/package.json
+++ b/tests/versioned/apollo-server-koa/package.json
@@ -8,8 +8,7 @@
         "node": ">=12"
       },
       "dependencies": {
-        "apollo-server-koa": ">=2.14.0 <3.4.0",
-        "koa": "2.13.1",
+        "apollo-server-koa": ">=2.14.0 <3.0.0",
         "graphql": "15.8.0"
       },
       "files": [

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Apr 14 2022 14:53:30 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Apr 18 2022 15:50:16 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Removed `koa` as a dependency from versions < 3.0.0 as it was already bundled with `apollo-sever-koa`.

## Links

## Details
Also things I did not worthy of release notes but good for context.

 * Updated the version matrix to exclude 3.0.0-3.3.x as this range hardcoded `koa` to a version.
 * Removed the multiple step versions tests for npm 6 as that does not get executed when running in agent, thus causing a difference between behavior when running tests in this repo vs as an external repo in agent.

I updated a local copy of agent and added this branch to `test/versioned-external/external-repos.js` and the tests for koa now pass 🎉

```sh
koa(1)
graphql(4)
apollo-server-koa(2)
===============================================================
 ✓ apollo-server-koa (10) 27s
===============================================================
Versions executed

Folder: apollo-server-koa
	 * apollo-server-koa(2): 2.25.3, 3.6.7
	 * graphql(1): 15.8.0
	 * koa(1): 2.13.4
===============================================================
PASS

real	0m27.072s
user	0m21.647s
sys	0m7.128s

real	0m27.081s
user	0m21.649s
sys	0m7.132s
```
