### PR TITLE
moved naming of transaction and updating operation segment to didResolveOperation, also added it to willSendResponse

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -100,39 +100,8 @@ function createPlugin(instrumentationApi, config = {}) {
       operationSegment.start()
 
       return {
-        /**
-         * The document AST has been parsed so we can attempt to name the operation
-         * and update the transaction name based on operation
-         */
-        validationDidStart(validationContext) {
-          const operationDetails = getOperationDetails(validationContext)
-          if (operationDetails) {
-            const { operationName, operationType, deepestUniquePath, cleanedQuery } =
-              operationDetails
-
-            operationSegment.addAttribute(OPERATION_QUERY_ATTR, cleanedQuery)
-
-            operationSegment.addAttribute(OPERATION_TYPE_ATTR, operationType)
-
-            if (operationName) {
-              operationSegment.addAttribute(OPERATION_NAME_ATTR, operationName)
-            }
-
-            const formattedName = operationName || ANON_PLACEHOLDER
-            let formattedOperation = `${operationType}/${formattedName}`
-
-            // Certain requests, such as introspection, won't hit any resolvers
-            if (deepestUniquePath) {
-              formattedOperation += `/${deepestUniquePath}`
-            }
-
-            const segmentName = formattedOperation
-            const transactionName = formattedOperation
-            setTransactionName(operationSegment.transaction, transactionName)
-            operationSegment.name = `${OPERATION_PREFIX}/${segmentName}`
-          }
-        },
         didResolveOperation(resolveContext) {
+          updateOperationSegmentName(resolveContext, operationSegment)
           if (shouldIgnoreTransaction(resolveContext.operation, config, logger)) {
             const activeSegment = instrumentationApi.getActiveSegment()
             if (activeSegment) {
@@ -223,11 +192,14 @@ function createPlugin(instrumentationApi, config = {}) {
             }
           }
         },
-        willSendResponse() {
+        willSendResponse(responseContext) {
           // check if operation segment was never updated from default name
-          // If so, update the transaction name to `*`
+          // If so, try to rename before setting the transaction name to `*`
           if (operationSegment.name === DEFAULT_OPERATION_NAME) {
-            setTransactionName(operationSegment.transaction, '*')
+            const updated = updateOperationSegmentName(responseContext, operationSegment)
+            if (!updated) {
+              setTransactionName(operationSegment.transaction, '*')
+            }
           }
           operationSegment.end()
 
@@ -528,6 +500,46 @@ function shouldIgnoreTransaction(operation, config, logger) {
         'Force ignoring the transaction.'
     )
 
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Attempts to extract the document from the request context and
+ * add attributes for the query, operation type, operation name and
+ * update the transaction name based on operation name as well
+ *
+ * @param {Object} context apollo request context
+ * @param {Segment} operationSegment default segment created in request start
+ * @return {Boolean} true if document could be parsed from context
+ */
+function updateOperationSegmentName(context, operationSegment) {
+  const operationDetails = getOperationDetails(context)
+  if (operationDetails) {
+    const { operationName, operationType, deepestUniquePath, cleanedQuery } = operationDetails
+
+    operationSegment.addAttribute(OPERATION_QUERY_ATTR, cleanedQuery)
+
+    operationSegment.addAttribute(OPERATION_TYPE_ATTR, operationType)
+
+    if (operationName) {
+      operationSegment.addAttribute(OPERATION_NAME_ATTR, operationName)
+    }
+
+    const formattedName = operationName || ANON_PLACEHOLDER
+    let formattedOperation = `${operationType}/${formattedName}`
+
+    // Certain requests, such as introspection, won't hit any resolvers
+    if (deepestUniquePath) {
+      formattedOperation += `/${deepestUniquePath}`
+    }
+
+    const segmentName = formattedOperation
+    const transactionName = formattedOperation
+    setTransactionName(operationSegment.transaction, transactionName)
+    operationSegment.name = `${OPERATION_PREFIX}/${segmentName}`
     return true
   }
 

--- a/tests/unit/create-plugin.test.js
+++ b/tests/unit/create-plugin.test.js
@@ -57,7 +57,7 @@ tap.test('createPlugin edge cases', (t) => {
 
     const hooks = createPlugin(instrumentationApi)
     const operationHooks = hooks.requestDidStart({})
-    operationHooks.validationDidStart(responseContext)
+    operationHooks.willSendResponse(responseContext)
     t.equal(
       operationSegment.name,
       'GraphQL/operation/ApolloServer/undefined/<anonymous>',
@@ -75,7 +75,7 @@ tap.test('createPlugin edge cases', (t) => {
       'GraphQL/operation/ApolloServer/<unknown>',
       'should default operation name'
     )
-    operationHooks.validationDidStart(responseContext)
+    operationHooks.willSendResponse(responseContext)
     t.equal(
       operationSegment.name,
       'GraphQL/operation/ApolloServer/<unknown>',

--- a/tests/versioned/apollo-server-lambda/attributes-tests.js
+++ b/tests/versioned/apollo-server-lambda/attributes-tests.js
@@ -5,8 +5,13 @@
 
 'use strict'
 
-const { executeQueryJson, executeQueryAssertResult } = require('./lambda-test-utils')
+const {
+  executeQueryJson,
+  executeQueryAssertResult,
+  createApiEvent
+} = require('./lambda-test-utils')
 const { findSegmentByName } = require('../../agent-testing')
+const { checkResult } = require('../common')
 
 const SEGMENT_DESTINATION = 0x20
 
@@ -614,6 +619,56 @@ function createAttributesTests(t) {
       context: stubContext,
       modVersion,
       t
+    })
+  })
+
+  t.test('should capture all attributes on multiple queries', (t) => {
+    const { helper, patchedHandler, stubContext } = t.context
+
+    const expectedName = 'HeyThere'
+    const query = `query ${expectedName} {
+      hello
+    }`
+
+    let count = 0
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      const operationName = `${OPERATION_PREFIX}/query/${expectedName}/hello`
+
+      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+      if (!operationSegment) {
+        const err = new Error(`Cannot find operation segment with name ${operationName}`)
+        t.error(err)
+        return
+      }
+
+      const expectedOperationAttributes = {
+        'graphql.operation.type': 'query',
+        'graphql.operation.query': query,
+        'graphql.operation.name': expectedName
+      }
+
+      const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
+
+      t.matches(
+        operationAttributes,
+        expectedOperationAttributes,
+        'should have operation attributes'
+      )
+      count++
+    })
+
+    const jsonQuery = JSON.stringify({ query })
+    const event = createApiEvent(jsonQuery)
+    patchedHandler(event, stubContext).then((result) => {
+      checkResult(t, result, async () => {
+        patchedHandler(event, stubContext).then((result2) => {
+          checkResult(t, result2, () => {
+            t.equal(count, 2, 'should have checked 2 transactions')
+            t.end()
+          })
+        })
+      })
     })
   })
 }

--- a/tests/versioned/apollo-server-lambda/lambda-test-utils.js
+++ b/tests/versioned/apollo-server-lambda/lambda-test-utils.js
@@ -51,7 +51,7 @@ utils.executeQueryAssertResult = async function executeQueryAssertResult({
   t
 }) {
   const jsonQuery = JSON.stringify({ query })
-  const event = createApiEvent(jsonQuery)
+  const event = utils.createApiEvent(jsonQuery)
 
   if (requiresCallback(modVersion)) {
     handler(event, context, resultCallback.bind(null, t))
@@ -83,7 +83,7 @@ utils.executeQueryJson = async function executeQueryJson({
   t
 }) {
   const jsonQuery = JSON.stringify(query)
-  const event = createApiEvent(jsonQuery)
+  const event = utils.createApiEvent(jsonQuery)
 
   if (requiresCallback(modVersion)) {
     handler(event, context, (err) => {
@@ -119,7 +119,7 @@ utils.executeBatchAssertResult = async function executeBatchAssertResult({
     return { query: innerQuery }
   })
   const jsonQuery = JSON.stringify(data)
-  const event = createApiEvent(jsonQuery)
+  const event = utils.createApiEvent(jsonQuery)
 
   if (requiresCallback(modVersion)) {
     handler(event, context, resultCallback.bind(null, t))
@@ -189,7 +189,7 @@ utils.executeQueryAssertErrors = async function executeQueryAssertErrors({
   code
 }) {
   const jsonQuery = JSON.stringify({ query })
-  const event = createApiEvent(jsonQuery)
+  const event = utils.createApiEvent(jsonQuery)
 
   if (requiresCallback(modVersion)) {
     handler(event, context, errorCallback.bind(null, t, code))
@@ -205,7 +205,7 @@ utils.executeQueryAssertErrors = async function executeQueryAssertErrors({
  *
  * @param {string} query to execute
  */
-function createApiEvent(query) {
+utils.createApiEvent = function createApiEvent(query) {
   const apiGatewayProxyEvent = {
     path: '/graphql',
     headers: {

--- a/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
+++ b/tests/versioned/apollo-server-lambda/transaction-naming-tests.js
@@ -6,10 +6,12 @@
 'use strict'
 
 const {
+  createApiEvent,
   executeBatchAssertResult,
   executeQueryAssertResult,
   executeQueryAssertErrors
 } = require('./lambda-test-utils')
+const { checkResult } = require('../common')
 
 const ANON_PLACEHOLDER = '<anonymous>'
 
@@ -456,6 +458,34 @@ function createTransactionTests(t, frameworkName) {
       modVersion,
       t,
       code: 'GRAPHQL_VALIDATION_FAILED'
+    })
+  })
+
+  t.test('multiple queries do not affect transaction naming', (t) => {
+    const { helper, patchedHandler, stubContext } = t.context
+
+    const expectedName = 'HeyThere'
+    const query = `query ${expectedName} {
+      hello
+    }`
+    let count = 0
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//query/${expectedName}/hello`)
+      count++
+    })
+
+    const jsonQuery = JSON.stringify({ query })
+    const event = createApiEvent(jsonQuery)
+    patchedHandler(event, stubContext).then((result) => {
+      checkResult(t, result, async () => {
+        patchedHandler(event, stubContext).then((result2) => {
+          checkResult(t, result2, () => {
+            t.equal(count, 2, 'should have checked 2 transactions')
+            t.end()
+          })
+        })
+      })
     })
   })
 }

--- a/tests/versioned/transaction-naming-tests.js
+++ b/tests/versioned/transaction-naming-tests.js
@@ -656,6 +656,34 @@ function createTransactionTests(t, frameworkName) {
       t.end()
     })
   })
+
+  t.test('multiple queries do not affect transaction naming', (t) => {
+    const { helper, serverUrl } = t.context
+
+    const expectedName = 'HeyThere'
+    const query = `query ${expectedName} {
+      hello
+    }`
+    let count = 0
+
+    helper.agent.on('transactionFinished', (transaction) => {
+      t.equal(transaction.name, `${EXPECTED_PREFIX}//query/${expectedName}/hello`)
+      count++
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      t.error(err)
+      checkResult(t, result, () => {
+        executeQuery(serverUrl, query, (err2, result2) => {
+          t.error(err2)
+          checkResult(t, result2, () => {
+            t.equal(count, 2, 'should have checked 2 transactions')
+            t.end()
+          })
+        })
+      })
+    })
+  })
 }
 
 module.exports = {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Moved naming of transaction to both `didResolveOperation`, and `willSendResponse` to properly handle when validation of document does not get invoked.

## Links
Closes #189 and #196

## Details
We had some poor assumptions around request life cycles within apollo server.  `validationDidStart` only fires on the first time a query is parsed, subsequent are cached, thus skipping this phase.  We had moved naming to this phase which resulted in many naming issues.  There is not a perfect solution here so we are now naming transactions in `didResolveOperation` and also checking in `willSendResponse` if the operation segment has been renamed since the default is set in `requestDidStart` and if not, attempt to update name from the document AST.

TODO:
 - [ ] Check the use case in #117 is still resolved(we had a hard time creating a reliable automated test but I want to open this PR first so our team could review)
