### PR TITLE
handle undefined operation

### DIFF
--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -458,10 +458,6 @@ function createModuleUsageMetric(agent) {
 }
 
 function isIntrospectionQuery(operation) {
-  if (!operation) {
-    return false
-  }
-
   return operation.selectionSet.selections.every((selection) => {
     const fieldName = selection.name.value
     return INTROSPECTION_TYPES.includes(fieldName)
@@ -469,25 +465,17 @@ function isIntrospectionQuery(operation) {
 }
 
 function isServiceDefinitionQuery(operation) {
-  if (!operation) {
-    return false
-  }
-
   return operation.name && operation.name.value === SERVICE_DEFINITION_QUERY_NAME
 }
 
 function isHealthCheckQuery(operation) {
-  if (!operation) {
-    return false
-  }
-
   return operation.name && operation.name.value === HEALTH_CHECK_QUERY_NAME
 }
 
 function shouldIgnoreTransaction(operation, config, logger) {
   if (!operation) {
-    logger.trace('`operation` is undefined. Force ignoring the transaction.')
-    return true
+    logger.trace('`operation` is undefined. Skipping query type check.')
+    return false
   }
 
   if (!config.captureIntrospectionQueries && isIntrospectionQuery(operation)) {

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -458,6 +458,10 @@ function createModuleUsageMetric(agent) {
 }
 
 function isIntrospectionQuery(operation) {
+  if (!operation) {
+    return false
+  }
+
   return operation.selectionSet.selections.every((selection) => {
     const fieldName = selection.name.value
     return INTROSPECTION_TYPES.includes(fieldName)
@@ -465,14 +469,27 @@ function isIntrospectionQuery(operation) {
 }
 
 function isServiceDefinitionQuery(operation) {
+  if (!operation) {
+    return false
+  }
+
   return operation.name && operation.name.value === SERVICE_DEFINITION_QUERY_NAME
 }
 
 function isHealthCheckQuery(operation) {
+  if (!operation) {
+    return false
+  }
+
   return operation.name && operation.name.value === HEALTH_CHECK_QUERY_NAME
 }
 
 function shouldIgnoreTransaction(operation, config, logger) {
+  if (!operation) {
+    logger.trace('`operation` is undefined. Force ignoring the transaction.')
+    return true
+  }
+
   if (!config.captureIntrospectionQueries && isIntrospectionQuery(operation)) {
     logger.trace(
       'Request is an introspection query and ' +

--- a/tests/unit/create-plugin.test.js
+++ b/tests/unit/create-plugin.test.js
@@ -83,4 +83,13 @@ tap.test('createPlugin edge cases', (t) => {
     )
     t.end()
   })
+
+  t.test('should not crash when ctx.operation is undefined in didResolveOperation', (t) => {
+    const hooks = createPlugin(instrumentationApi)
+    const operationHooks = hooks.requestDidStart({})
+    t.doesNotThrow(() => {
+      operationHooks.didResolveOperation({})
+    })
+    t.end()
+  })
 })


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added defensive code to prevent plugin from masking actual graphql errors.

## Links
Closes #206 


## Details
We are currently using the newrelic addin for apollo graphql along with the graphql-upload package to support file uploads via our graphql api.

For some upload requests we are receiving an error from the newrelic plugin that is preventing the upload request from continuing/completing.

Upon investigating the issue, is seems to be caused due to the "operation" being undefined within the newrelic plugin for these requests. The current plugin code doesn't have guards to consider this scenario resulting in an unhandled error.

**Example GQL Request:**
```
mutation($file: Upload!)
{
    upload(input : {file: $file})
    {
        code,
        error,
        message,
        uniqueId
    }
}
```
**Example Response**
```
{
  "errors": [
    {
      "message": "Cannot read properties of undefined (reading 'selectionSet')",
      "extensions":
      {
        "code": "INTERNAL_SERVER_ERROR",
        "exception":
        {
          "stacktrace": ["TypeError: Cannot read properties of undefined (reading 'selectionSet')", "    at isIntrospectionQuery (/node_modules/@newrelic/apollo-server-plugin/lib/create-plugin.js:461:20)", "    at shouldIgnoreTransaction (/node_modules/@newrelic/apollo-server-plugin/lib/create-plugin.js:476:46)", "    at Object.didResolveOperation (/node_modules/@newrelic/apollo-server-plugin/lib/create-plugin.js:105:15)", "    at /node_modules/apollo-server-core/dist/utils/dispatcher.js:21:31", "    at Array.map (<anonymous>)", "    at Dispatcher.callTargets (/node_modules/apollo-server-core/dist/utils/dispatcher.js:18:24)", "    at Dispatcher.<anonymous> (/node_modules/apollo-server-core/dist/utils/dispatcher.js:27:43)", "    at Generator.next (<anonymous>)", "    at /node_modules/apollo-server-core/dist/utils/dispatcher.js:8:71", "    at new Promise (<anonymous>)"]
        }
      }
    }
  ]
}
```