### PR TITLE
README.md: document that the minimum version of apollo-server is 2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # New Relic Apollo Server plugin ![Apollo Server Plugin CI](https://github.com/newrelic/newrelic-node-apollo-server-plugin/workflows/Apollo%20Server%20Plugin%20CI/badge.svg)
 
-New Relic's official Apollo Server plugin for use with the [Node.js agent](https://github.com/newrelic/node-newrelic).
+New Relic's official Apollo Server plugin for use with the [Node.js agent](https://github.com/newrelic/node-newrelic). The supported Apollo Server version is 2.14 or later.
 
 This plugin expects the Node.js agent [newrelic npm package](https://www.npmjs.com/package/newrelic) has already been installed in your application.
 
@@ -46,7 +46,7 @@ const server = new ApolloServer({
 ## Usage
 
 The New Relic plugin is known to work with the following Apollo Server modules:
-* apollo-server
+* apollo-server (>= 2.14)
 * apollo-server-express
 * apollo-server-hapi
 * apollo-server-koa


### PR DESCRIPTION
## Proposed Release Notes

* Added minimum supported server version to README.md

## Links

* closes #133 

## Details

* Formal support for the `willResolveField` plugin hook that we’re relying on wasn’t introduced until apollo-server@2.14 -- https://github.com/apollographql/apollo-server/blob/main/CHANGELOG.md#v214