### PR TITLE
Fix apollo versioned tests run schemas

### DIFF
--- a/bin/run-versioned-tests.sh
+++ b/bin/run-versioned-tests.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+set -x
+VERSIONED_MODE="${VERSIONED_MODE:---minor}"
+SAMPLES="${SAMPLES:-15}"
+
+if [ $SAMPLES -le 10 ];
+then
+  C8="c8 -o ./coverage/versioned"
+else
+  C8=""
+fi
+
+if [[ "${NPM7}" = 1 ]];
+then
+  $C8 ./node_modules/.bin/versioned-tests $VERSIONED_MODE --all --samples $SAMPLES -i 2 'tests/versioned/*'
+else
+  $C8 ./node_modules/.bin/versioned-tests $VERSIONED_MODE --samples $SAMPLES -i 2 'tests/versioned/*'
+fi
+

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "type-check": "tsd",
     "versioned": "npm run versioned:npm7",
     "versioned:folder": "versioned-tests --minor --all -i 2",
-    "versioned:major": "versioned-tests --major --all -i 2 'tests/versioned/*'",
-    "versioned:npm6": "SAMPLES=\"${SAMPLES:-15}\"; c8 -o ./coverage/versioned versioned-tests --minor --samples $SAMPLES -i 2 'tests/versioned/*'",
-    "versioned:npm7": "SAMPLES=\"${SAMPLES:-15}\"; c8 -o ./coverage/versioned versioned-tests --minor --all --samples $SAMPLES -i 2 'tests/versioned/*'"
+    "versioned:major": "VERSIONED_MODE=--major npm run versioned:npm7",
+    "versioned:npm6": "./bin/run-versioned-tests.sh",
+    "versioned:npm7": "NPM7=1 ./bin/run-versioned-tests.sh"
   },
   "files": [
     "index.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Thu Oct 27 2022 14:14:46 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Thu Oct 27 2022 17:00:43 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
I added all this logic to prevent uploading coverage reports when in main but overlooked the fact that the versioned test script still ran with c8 which was causing the [crash](https://github.com/newrelic/newrelic-node-apollo-server-plugin/actions/runs/3340461486/jobs/5530580708). This PR moves the versioned test to a bash script and adds all the 🔔 and whistles.
