### PR TITLE
Fixes to appease the versioned-external gods

### DIFF
--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -30,7 +30,8 @@
       "dependencies": {
         "@apollo/server": ">=4.0.0",
         "graphql": "16.6.0",
-        "body-parser": "latest"
+        "body-parser": "latest",
+        "graphql-tag": "latest"
       },
       "files": [
         "transaction-naming.test.js",

--- a/tests/versioned/apollo-server/apollo-server-setup.js
+++ b/tests/versioned/apollo-server/apollo-server-setup.js
@@ -19,7 +19,8 @@ function loadApolloServer() {
     const gql = require('graphql-tag')
     const apolloServer = require('@apollo/server')
     const { startStandaloneServer } = require('@apollo/server/standalone')
-    return { gql, ...apolloServer, startStandaloneServer }
+    const graphql = require('graphql')
+    return { gql, ...apolloServer, startStandaloneServer, graphql }
   } catch {
     return require('apollo-server')
   }

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -30,7 +30,7 @@
       "dependencies": {
         "@apollo/server": ">=4.0.0",
         "graphql": "16.6.0",
-        "graphql-tag": "2.12.6"
+        "graphql-tag": "latest"
       },
       "files": [
         "transaction-naming.test.js",

--- a/tests/versioned/error-setup.js
+++ b/tests/versioned/error-setup.js
@@ -5,8 +5,8 @@
 
 'use strict'
 
-function createErrorClasses() {
-  const { GraphQLError } = require('graphql')
+function createErrorClasses(serverPkgExport) {
+  const { GraphQLError } = serverPkgExport.graphql
 
   class CustomError extends GraphQLError {
     constructor(message) {
@@ -81,7 +81,7 @@ module.exports = function setupErrorResolvers(serverPkgExport, resolvers, isApol
     UserInputError,
     ValidationError,
     AuthenticationError
-  } = isApollo4 ? createErrorClasses() : serverPkgExport
+  } = isApollo4 ? createErrorClasses(serverPkgExport) : serverPkgExport
 
   resolvers.Query.boom = () => {
     throw new Error('Boom goes the dynamite!')


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
[Failed Agent CI](https://github.com/newrelic/node-newrelic/actions/runs/3396698922/jobs/5648237228)

## Details
We have some smells in our versioned tests.  Since apollo server gets installed as a dev dep of the repo, it was masking issues.  This PR fixes a few big ones:
 * properly defining all deps for a given test suite
 * favoring checking for `@apollo/server` vs `apollo-server` to determine if we want to test 4.x+ of apollo.
 * fixing issues from the assumptions on bullet 2

I did verify these fixes will work against agent by adding my branch to the agent

```sh
--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -34,13 +34,14 @@ const repos = [
   },
   {
     name: 'apollo-server',
-    repository: 'https://github.com/newrelic/newrelic-node-apollo-server-plugin.git',
-    branch: 'main',
+    repository: 'https://github.com/bizob2828/newrelic-node-apollo-server-plugin.git',
+    branch: 'fix-external-versioned',
     additionalFiles: [
       'tests/agent-testing.js',
       'tests/create-apollo-server-setup.js',
       'tests/data-definitions.js',
-      'tests/test-client.js'
+      'tests/test-client.js',
+      'tests/utils.js'
     ]
   }
 ]
```

I ran and
```sh
===============================================================
PASS

real	2m49.442s
user	7m29.512s
sys	1m47.338s
      169.44 real       449.51 user       107.34 sys
```
