### PR TITLE
NEWRELIC-4422 updated apollo server plugin tests to deleted cached agent from prop or symbol on require.cache

### DIFF
--- a/tests/integration/bootstrap.test.js
+++ b/tests/integration/bootstrap.test.js
@@ -59,7 +59,19 @@ function resetModuleCache(callback) {
   delete require.cache[newrelicPath]
   delete require.cache[newrelicLogger]
   delete require.cache[newrelicConfig]
-  delete require.cache.__NR_cache
+
+  // In 9.6.0 of the agent the cached agent moved from a property
+  // to a symbol. Look up the symbol and then delete cached agent
+  // from prop or symbol.
+  const [agentCacheSym] = Object.getOwnPropertySymbols(require.cache).filter(
+    (name) => name.toString() === 'Symbol(cache)'
+  )
+
+  if (require.cache.__NR_cache) {
+    delete require.cache.__NR_cache
+  } else {
+    delete require.cache[agentCacheSym]
+  }
 
   callback()
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
The apollo server plugin tests will eventually fail when we release the new agent version that removes the dunder `__NR` props and replaces with symbols. This fix will work with both

To test
```sh
npm ci
npm run integration
```

To test with symbols

```sh
# In agent repo
npm ci
npm link

# In PR branch
npm ci
npm link newrelic
npm run integration
```
