### PR TITLE
NEWRELIC-5907 Updated types definition to use user provided type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,34 @@ const server = new ApolloServer({
 })
 ```
 
-**Note**: If you are using typescript and `@apollo/server` to load the plugin, you must pass in the appropriate `ApolloServerPlugin` type.
+**Note**: If you are using Typescript, you must pass in the appropriate `ApolloServerPlugin` type.
 
+**Using Apollo V4**
 ```ts
 // index.ts
 
 import { ApolloServerPlugin, ApolloServer } from '@apollo/server';
 import createNewRelicPlugin from '@newrelic/apollo-server-plugin';
 
-const newRelicPlugin = createNewRelicPlugin<ApolloServerPlugin>({}) 
+const newRelicPlugin = createNewRelicPlugin<ApolloServerPlugin>({})
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  plugins: [
+    newRelicPlugin,
+  ],
+});
+```
+
+**Using Apollo V3**
+```ts
+// index.ts
+
+import { ApolloServer } from 'apollo-server';
+import { ApolloServerPlugin } from 'apollo-server-plugin-base';
+import createNewRelicPlugin from '@newrelic/apollo-server-plugin';
+
+const newRelicPlugin = createNewRelicPlugin<ApolloServerPlugin>({})
 const server = new ApolloServer({
   typeDefs,
   resolvers,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,3 @@
-import type { ApolloServerPlugin as Base } from 'apollo-server-plugin-base';
-import type { ApolloServerPlugin } from '@apollo/server';
-
 export type NRPluginConfig = {
   captureScalars?: boolean;
   captureIntrospectionQueries?: boolean;
@@ -8,4 +5,4 @@ export type NRPluginConfig = {
   captureHealthCheckQueries?: boolean;
 };
 
-export default function createPlugin<T>(config?: NRPluginConfig): T extends ApolloServerPlugin ? ApolloServerPlugin : Base; 
+export default function createPlugin<T>(config?: NRPluginConfig): T;

--- a/tests/types/index.test-d.ts
+++ b/tests/types/index.test-d.ts
@@ -1,9 +1,17 @@
 import { ApolloServerPlugin as V3Plugin } from "apollo-server-plugin-base";
 import { ApolloServerPlugin as V4Plugin } from "@apollo/server";
-import { expectType } from "tsd";
+import { expectType, expectNotType } from "tsd";
 
 import createPlugin from "../..";
 
+
+interface foo {}
+const plugin: foo = createPlugin({})
+expectNotType<V3Plugin>(plugin)
+expectNotType<V3Plugin>(createPlugin<foo>({}))
+
+const pluginV3: V3Plugin = createPlugin({})
+expectType<V3Plugin>(pluginV3)
 expectType<V3Plugin>(createPlugin<V3Plugin>({}));
 expectType<V3Plugin>(
   createPlugin<V3Plugin>({
@@ -13,6 +21,8 @@ expectType<V3Plugin>(
   })
 );
 
+const pluginV4: V4Plugin = createPlugin({})
+expectType<V4Plugin>(pluginV4)
 expectType<V4Plugin>(createPlugin<V4Plugin>({}))
 expectType<V4Plugin>(
   createPlugin<V4Plugin>({

--- a/tests/types/index.test-d.ts
+++ b/tests/types/index.test-d.ts
@@ -1,23 +1,21 @@
-import { ApolloServerPlugin as Base } from "apollo-server-plugin-base";
-import { ApolloServerPlugin } from "@apollo/server";
+import { ApolloServerPlugin as V3Plugin } from "apollo-server-plugin-base";
+import { ApolloServerPlugin as V4Plugin } from "@apollo/server";
 import { expectType } from "tsd";
 
 import createPlugin from "../..";
 
-expectType<Base>(createPlugin({}));
-
-expectType<Base>(
-  createPlugin({
+expectType<V3Plugin>(createPlugin<V3Plugin>({}));
+expectType<V3Plugin>(
+  createPlugin<V3Plugin>({
     captureHealthCheckQueries: true,
     captureScalars: false,
     captureServiceDefinitionQueries: true,
   })
 );
 
-expectType<ApolloServerPlugin>(createPlugin<ApolloServerPlugin>({}))
-
-expectType<ApolloServerPlugin>(
-  createPlugin<ApolloServerPlugin>({
+expectType<V4Plugin>(createPlugin<V4Plugin>({}))
+expectType<V4Plugin>(
+  createPlugin<V4Plugin>({
     captureHealthCheckQueries: true,
     captureScalars: false,
     captureServiceDefinitionQueries: true,


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
**BREAKING**: Updated types definition to use user provided type
If your application uses both Typescript and Apollo version 3, you'll need to update where you configure the New Relic plugin to include the `ApolloServerPlugin` type from `apollo-server-plugin-base`, like in the following: 
```ts
import { ApolloServer } from 'apollo-server';
import { ApolloServerPlugin } from 'apollo-server-plugin-base';
import createNewRelicPlugin from '@newrelic/apollo-server-plugin';
const newRelicPlugin = createNewRelicPlugin<ApolloServerPlugin>({})
const server = new ApolloServer({
  typeDefs,
  resolvers,
  plugins: [
    newRelicPlugin,
  ],
});
```

## Links
Fixes #233 

## Details
This is a semver major change, since there's no good way for us to support both the apollo@3 and apollo@4 `ApolloServerPlugin` type inside our types file, we're switching to a generic type that must be passed in, requiring users to provide the `ApolloServerPlugin` type that's most appropriate for their Apollo application. The reason for the semver major change is because this is a backwards incompatible change for apollo@3 Typescript users, they will now have to provide the correct type like apollo@4 Typescript users (see README.md change for an example).