### PR TITLE
node 20

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3
@@ -92,15 +92,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm ci
-    - name: Run Versioned Tests (npm v6 / Node 14)
-      if: ${{ matrix.node-version == '14.x' }}
-      run: npm run versioned:npm6
-      env:
-        VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
-        C8_REPORTER: lcovonly
-    - name: Run Versioned Tests (npm v7+ / Node 16+)
-      if: ${{ matrix.node-version != '14.x' }}
-      run: npm run versioned:npm7
+    - name: Run Versioned Tests
+      run: npm run versioned
       env:
         VERSIONED_MODE: ${{ github.ref == 'refs/heads/main' && '--minor' || '--major' }}
         C8_REPORTER: lcovonly

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -46,7 +46,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 
 ### @apollo/server
 
-This product includes source derived from [@apollo/server](https://github.com/apollographql/apollo-server) ([v4.1.1](https://github.com/apollographql/apollo-server/tree/v4.1.1)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v4.1.1/README.md):
+This product includes source derived from [@apollo/server](https://github.com/apollographql/apollo-server) ([v4.7.4](https://github.com/apollographql/apollo-server/tree/v4.7.4)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v4.7.4/README.md):
 
 ```
 MIT License
@@ -717,7 +717,7 @@ SOFTWARE.
 
 ### c8
 
-This product includes source derived from [c8](https://github.com/bcoe/c8) ([v7.12.0](https://github.com/bcoe/c8/tree/v7.12.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v7.12.0/LICENSE.txt):
+This product includes source derived from [c8](https://github.com/bcoe/c8) ([v7.14.0](https://github.com/bcoe/c8/tree/v7.14.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v7.14.0/LICENSE.txt):
 
 ```
 Copyright (c) 2017, Contributors
@@ -1158,7 +1158,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v9.14.0](https://github.com/newrelic/node-newrelic/tree/v9.14.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v9.14.0/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v10.3.2](https://github.com/newrelic/node-newrelic/tree/v10.3.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v10.3.2/LICENSE):
 
 ```
                                  Apache License

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -717,7 +717,7 @@ SOFTWARE.
 
 ### c8
 
-This product includes source derived from [c8](https://github.com/bcoe/c8) ([v7.14.0](https://github.com/bcoe/c8/tree/v7.14.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v7.14.0/LICENSE.txt):
+This product includes source derived from [c8](https://github.com/bcoe/c8) ([v7.12.0](https://github.com/bcoe/c8/tree/v7.12.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v7.12.0/LICENSE.txt):
 
 ```
 Copyright (c) 2017, Contributors

--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
     "third-party-updates": "oss third-party manifest && oss third-party notices && git add THIRD_PARTY_NOTICES.md third_party_manifest.json",
     "unit": "c8 -o ./coverage/unit tap --test-regex='(\\/|^tests\\/unit\\/.*\\.test\\.js)$' --no-coverage",
     "type-check": "tsd",
-    "versioned": "npm run versioned:npm7",
+    "versioned": "NPM7=1 ./bin/run-versioned-tests.sh",
     "versioned:folder": "versioned-tests --minor --all -i 2",
-    "versioned:major": "VERSIONED_MODE=--major npm run versioned:npm7",
-    "versioned:npm6": "./bin/run-versioned-tests.sh",
-    "versioned:npm7": "NPM7=1 ./bin/run-versioned-tests.sh"
+    "versioned:major": "VERSIONED_MODE=--major npm run versioned"
   },
   "files": [
     "index.js",

--- a/tests/versioned/apollo-server-hapi/apollo-server-hapi-setup.js
+++ b/tests/versioned/apollo-server-hapi/apollo-server-hapi-setup.js
@@ -50,8 +50,7 @@ function setupApolloServerHapiTests({ suiteName, createTests, pluginConfig }, co
       })
 
       hapiServer = Hapi.server({
-        host: 'localhost',
-        port: 5000
+        host: 'localhost'
       })
 
       await server.start()
@@ -59,7 +58,7 @@ function setupApolloServerHapiTests({ suiteName, createTests, pluginConfig }, co
 
       await hapiServer.start()
 
-      serverUrl = `http://localhost:${hapiServer.settings.port}${graphqlPath}`
+      serverUrl = `http://localhost:${hapiServer.info.port}${graphqlPath}`
       t.context.helper = helper
       t.context.serverUrl = serverUrl
     })

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Jul 11 2023 11:28:56 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Tue Jul 18 2023 11:47:10 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -7,15 +7,15 @@
   "includeDev": true,
   "dependencies": {},
   "devDependencies": {
-    "@apollo/server@4.1.1": {
+    "@apollo/server@4.7.4": {
       "name": "@apollo/server",
-      "version": "4.1.1",
+      "version": "4.7.4",
       "range": "^4.1.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/apollographql/apollo-server",
-      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v4.1.1",
+      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v4.7.4",
       "licenseFile": "node_modules/@apollo/server/README.md",
-      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v4.1.1/README.md",
+      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v4.7.4/README.md",
       "licenseTextSource": "spdx",
       "publisher": "Apollo",
       "email": "packages@apollographql.com"
@@ -71,15 +71,15 @@
       "publisher": "Apollo",
       "email": "packages@apollographql.com"
     },
-    "c8@7.12.0": {
+    "c8@7.14.0": {
       "name": "c8",
-      "version": "7.12.0",
+      "version": "7.14.0",
       "range": "^7.14.0",
       "licenses": "ISC",
       "repoUrl": "https://github.com/bcoe/c8",
-      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v7.12.0",
+      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v7.14.0",
       "licenseFile": "node_modules/c8/LICENSE.txt",
-      "licenseUrl": "https://github.com/bcoe/c8/blob/v7.12.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/bcoe/c8/blob/v7.14.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Ben Coe",
       "email": "ben@npmjs.com"
@@ -196,15 +196,15 @@
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@9.14.0": {
+    "newrelic@10.3.2": {
       "name": "newrelic",
-      "version": "9.14.0",
-      "range": "^9.14.0",
+      "version": "10.3.2",
+      "range": "^10.3.2",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v9.14.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v10.3.2",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v9.14.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v10.3.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed May 31 2023 15:56:59 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Tue Jul 11 2023 11:28:56 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -71,15 +71,15 @@
       "publisher": "Apollo",
       "email": "packages@apollographql.com"
     },
-    "c8@7.14.0": {
+    "c8@7.12.0": {
       "name": "c8",
-      "version": "7.14.0",
+      "version": "7.12.0",
       "range": "^7.14.0",
       "licenses": "ISC",
       "repoUrl": "https://github.com/bcoe/c8",
-      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v7.14.0",
+      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v7.12.0",
       "licenseFile": "node_modules/c8/LICENSE.txt",
-      "licenseUrl": "https://github.com/bcoe/c8/blob/v7.14.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/bcoe/c8/blob/v7.12.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Ben Coe",
       "email": "ben@npmjs.com"


### PR DESCRIPTION
- chore: added node 20 and drop node 14 in CI
- test: updated hapi tests to no longer rely on a static port

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated CI to run against versions 16-20.

## Links
Closes #262 

## Details
