### PR TITLE
fix: added captureFieldMetrics, customResolverAttributes, and customerOperationAttributes to the type file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,9 @@ export type NRPluginConfig = {
   captureIntrospectionQueries?: boolean;
   captureServiceDefinitionQueries?: boolean;
   captureHealthCheckQueries?: boolean;
+  customResolverAttributes?: Function|null;
+  customOperationAttributes?: Function|null;
+  captureFieldMetrics?: boolean;
 };
 
 export default function createPlugin<T>(config?: NRPluginConfig): T;

--- a/tests/types/index.test-d.ts
+++ b/tests/types/index.test-d.ts
@@ -18,6 +18,9 @@ expectType<V3Plugin>(
     captureHealthCheckQueries: true,
     captureScalars: false,
     captureServiceDefinitionQueries: true,
+    captureFieldMetrics: true,
+    customOperationAttributes: (ctx: any) => ({ key: ctx.foo }),
+    customResolverAttributes: (ctx: any) => ({ attr: ctx.bar })
   })
 );
 
@@ -29,5 +32,8 @@ expectType<V4Plugin>(
     captureHealthCheckQueries: true,
     captureScalars: false,
     captureServiceDefinitionQueries: true,
+    captureFieldMetrics: true,
+    customOperationAttributes: (ctx: any) => ({ key: ctx.foo }),
+    customResolverAttributes: (ctx: any) => ({ attr: ctx.bar })
   })
 );


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Added `captureFieldMetrics`, `customResolverAttributes`, and `customerOperationAttributes` to the type file.

## Links
Closes #264

## Details
I wasn't sure if I wanted to complete define the interface of those callbacks with the context from apollo and it must return an object of key/values.

