### PR TITLE
feat: enhance typings for customResolverAttributes and customOperationAttributes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,17 @@
-export type NRPluginConfig = {
+export type NRPluginConfig<U = any, V = any> = {
   captureScalars?: boolean;
   captureIntrospectionQueries?: boolean;
   captureServiceDefinitionQueries?: boolean;
   captureHealthCheckQueries?: boolean;
-  customResolverAttributes?: Function|null;
-  customOperationAttributes?: Function|null;
+  customResolverAttributes?: (
+    resolverArguments: U
+  ) => Record<string, string | number | boolean> | null;
+  customOperationAttributes?: (
+    requestContext: V
+  ) => Record<string, string | number | boolean> | null;
   captureFieldMetrics?: boolean;
 };
 
-export default function createPlugin<T>(config?: NRPluginConfig): T;
+export default function createPlugin<T, U = any, V = any>(
+  config?: NRPluginConfig<U, V>
+): T;

--- a/tests/types/index.test-d.ts
+++ b/tests/types/index.test-d.ts
@@ -4,36 +4,45 @@ import { expectType, expectNotType } from "tsd";
 
 import createPlugin from "../..";
 
-
 interface foo {}
-const plugin: foo = createPlugin({})
-expectNotType<V3Plugin>(plugin)
-expectNotType<V3Plugin>(createPlugin<foo>({}))
+const plugin: foo = createPlugin({});
+expectNotType<V3Plugin>(plugin);
+expectNotType<V3Plugin>(createPlugin<foo>({}));
 
-const pluginV3: V3Plugin = createPlugin({})
-expectType<V3Plugin>(pluginV3)
+const pluginV3: V3Plugin = createPlugin({});
+expectType<V3Plugin>(pluginV3);
 expectType<V3Plugin>(createPlugin<V3Plugin>({}));
 expectType<V3Plugin>(
-  createPlugin<V3Plugin>({
+  createPlugin<
+    V3Plugin,
+    { source: any; args: any; context: { bar: string }; info: any },
+    { bar: string }
+  >({
     captureHealthCheckQueries: true,
     captureScalars: false,
     captureServiceDefinitionQueries: true,
     captureFieldMetrics: true,
-    customOperationAttributes: (ctx: any) => ({ key: ctx.foo }),
-    customResolverAttributes: (ctx: any) => ({ attr: ctx.bar })
+    customOperationAttributes: (ctx) => ({
+      attr: ctx.bar,
+    }),
+    customResolverAttributes: (ctx) => ({ attr: ctx.context.bar }),
   })
 );
 
-const pluginV4: V4Plugin = createPlugin({})
-expectType<V4Plugin>(pluginV4)
-expectType<V4Plugin>(createPlugin<V4Plugin>({}))
+const pluginV4: V4Plugin = createPlugin({});
+expectType<V4Plugin>(pluginV4);
+expectType<V4Plugin>(createPlugin<V4Plugin>({}));
 expectType<V4Plugin>(
-  createPlugin<V4Plugin>({
+  createPlugin<
+    V4Plugin,
+    { source: any; args: any; contextValue: { bar: string }; info: any },
+    { bar: string }
+  >({
     captureHealthCheckQueries: true,
     captureScalars: false,
     captureServiceDefinitionQueries: true,
     captureFieldMetrics: true,
-    customOperationAttributes: (ctx: any) => ({ key: ctx.foo }),
-    customResolverAttributes: (ctx: any) => ({ attr: ctx.bar })
+    customOperationAttributes: (ctx) => ({ key: ctx.bar }),
+    customResolverAttributes: (ctx) => ({ attr: ctx.contextValue.bar }),
   })
 );


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

This change enhances the typings for customResolverAttributes and customOperationAttributes so that it enforces the value in the key/value pairs returned must be a string | number | boolean.  It also uses generics so that the consumer can correctly type the function parameters regardless if they are using v3 or v4 of Apollo Server

## Proposed Release Notes

## Links

## Details
