### PR TITLE
fix(types): fix incorrect typescript export declaration

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -1,0 +1,13 @@
+export type NRPluginConfig<U = any, V = any> = {
+  captureScalars?: boolean;
+  captureIntrospectionQueries?: boolean;
+  captureServiceDefinitionQueries?: boolean;
+  captureHealthCheckQueries?: boolean;
+  customResolverAttributes?: (
+    resolverArguments: U
+  ) => Record<string, string | number | boolean> | null;
+  customOperationAttributes?: (
+    requestContext: V
+  ) => Record<string, string | number | boolean> | null;
+  captureFieldMetrics?: boolean;
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,17 +1,7 @@
-export type NRPluginConfig<U = any, V = any> = {
-  captureScalars?: boolean;
-  captureIntrospectionQueries?: boolean;
-  captureServiceDefinitionQueries?: boolean;
-  captureHealthCheckQueries?: boolean;
-  customResolverAttributes?: (
-    resolverArguments: U
-  ) => Record<string, string | number | boolean> | null;
-  customOperationAttributes?: (
-    requestContext: V
-  ) => Record<string, string | number | boolean> | null;
-  captureFieldMetrics?: boolean;
-};
+import type { NRPluginConfig } from './config';
 
-export default function createPlugin<T, U = any, V = any>(
+declare function createPlugin<T, U = any, V = any>(
   config?: NRPluginConfig<U, V>
 ): T;
+
+export = createPlugin;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "config.d.ts",
     "lib/*.js"
   ],
   "repository": {


### PR DESCRIPTION
## Proposed Release Notes

Fixes typescript type declarations to correctly define the exports for this package. Since there is only a single export, if you need to import the type for the plugin config explicitly you would need to import it from `/config`, eg, `import type { NRPluginConfig } from '@newrelic/apollo-server-plugin/config'`.

## Links

N/A

## Details

This package is a commonjs package where the main function is exported using `module.exports = createPlugin.bind(null, newrelic)`. The type declarations however state `export default function createPlugin`, which is incorrect (it would be correct if the main function were exported at `modules.exports.default = createPlugin.bind(null, newrelic)`. When you're working with commonjs this isn't so much of an issue, as most compilers will be using es module interop, but when you're actually using es modules there is a real different between those two exports, and typescript fails to compile with the current types. This change updates the type declarations included in the package to reflect the actual exported code.

There is a minor downside to this approach thats worth noting, in that previously you could have imported both the type for the plugin config and the createPlugin function itself from the top level of the package. That would have been possible to do if this package was using a default export, but since it isn't, and is doing `module.exports = createPlugin` it's impossible for it to export anything else. To work around that issue in case anyone does need to import the type for the plugin config, I moved it to a new `config.d.ts` and included that in the package.

The tldr for that is that while previously you could have done something like:

```typescript
import createNewRelicPlugin, { type NRPluginConfig } from '@newrelic/apollo-server-plugin';
```

you would now have to do

```typescript
import createNewRelicPlugin from '@newrelic/apollo-server-plugin';
import type { NRPluginConfig } from '@newrelic/apollo-server-plugin/config';
```

while that might be frustrating, it's an unfortunate side effect of the existing type declarations being wrong.