### PR TITLE
feat: Send error extensions as custom attributes

### DIFF
--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -32,7 +32,7 @@ class ErrorHelper {
     error = error.originalError || error
     const activeSegment = instrumentationApi.getActiveSegment()
     const transaction = activeSegment && activeSegment.transaction
-    instrumentationApi.agent.errors.add(transaction, error)
+    instrumentationApi.agent.errors.add(transaction, error, error.extensions)
   }
 }
 

--- a/tests/versioned/errors-tests.js
+++ b/tests/versioned/errors-tests.js
@@ -221,9 +221,10 @@ function createErrorTests(t, _, isApollo4) {
         t.equal(errorMessage, expectedErrorMessage)
         t.equal(errorType, expectedErrorType)
 
-        const { agentAttributes } = params
+        const { agentAttributes, userAttributes } = params
 
         t.ok(agentAttributes.spanId)
+        t.equal(userAttributes.code, code)
 
         const matchingSpan = agentTesting.findSpanById(helper.agent, agentAttributes.spanId)
 


### PR DESCRIPTION
The `GraphQLError`, which is used as a standard error type in ApolloServer, defines a [custom attribute of `extensions`][1] where developers can add custom attributes to help them group errors. Send through this attribute as custom attributes to NewRelic when catching exceptions.

If users want to not pass through the extensions they can use the standard attribute `include` and `exclude` rules to control them.

[1]: https://github.com/graphql/graphql-js/blob/688ee2f2a2f938e80bcf3808bc435d3d87a3ff3e/src/error/GraphQLError.ts

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated error handling to pass in [extensions](https://www.apollographql.com/docs/apollo-server/data/errors/) properties through as custom attributes.

   Thanks for the contribution @edds  🚀 

## Links
Closes #280 

## Details
