### PR TITLE
feat!: Removed GraphQL/typedResolve/ApolloServer/<parentType>.<resolver> in lieu of including the <parentType> in GraphQL/resolve/ApolloServer metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -18,10 +18,9 @@ Operation metrics include the operation type, operation name and deepest-path. T
 
 ## Field Resolve Metrics
 
-`/GraphQL/resolve/ApolloServer/[field-name]`
-`/GraphQL/typedResolve/ApolloServer/[parent-type].[field-name]`
+`/GraphQL/resolve/ApolloServer/[parent-type].[field-name]`
 
-Resolve metrics capture the duration spent resolving a particular piece of requested GraphQL data. These can be useful to find specific resolvers that may contribute to slowing down incoming queries. The metric with `typedResolve` in its prefix can be helpful for distinguishing field resolvers that happen to have the same name but are on different types. The metric without the parent type can be helpful in case of the same resolver being used across different types. 
+Resolve metrics capture the duration spent resolving a particular piece of requested GraphQL data. These can be useful to find specific resolvers that may contribute to slowing down incoming queries. It can be helpful for distinguishing field resolvers that happen to have the same name but are on different types. It can also be can be helpful in case of the same resolver being used across different types. 
 
 These differ slightly in naming from their segment/span counterparts. To better visualize relationships, the full path to a field is represented in segments/spans (e.g. libraries.books.title). To understand the duration aggregated across all usages and transactions, these metrics use the field name without the full path.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -75,6 +75,13 @@ If you would like to have a list of the top 10 slowest resolves, the following q
 
 ```
 FROM Metric
+SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{type}.{field}' FACET field LIMIT 20
+```
+
+If you would like to include the parent type.
+
+```
+FROM Metric
 SELECT average(newrelic.timeslice.value) * 1000 as 'Average Duration (MS)' WHERE appName = '[YOUR APP NAME]' WITH METRIC_FORMAT 'GraphQL/resolve/ApolloServer/{field}' FACET field LIMIT 20
 ```
 

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -19,7 +19,6 @@ const OPERATION_PREFIX = CATEGORY + '/operation/' + FRAMEWORK
 const RESOLVE_PREFIX = CATEGORY + '/resolve/' + FRAMEWORK
 const ARG_PREFIX = `${CATEGORY}/arg/${FRAMEWORK}`
 const FIELD_PREFIX = `${CATEGORY}/field/${FRAMEWORK}`
-const TYPED_RESOLVE_PREFIX = CATEGORY + '/typedResolve/' + FRAMEWORK
 const BATCH_PREFIX = 'batch'
 
 const DEFAULT_OPERATION_NAME = `${OPERATION_PREFIX}/<unknown>`
@@ -66,7 +65,6 @@ function createPlugin(api, config = {}) {
   config.customResolverAttributes = config.customResolverAttributes || null
   config.customOperationAttributes = config.customOperationAttributes || null
   config.captureFieldMetrics = config.captureFieldMetrics || false
-
   logger.debug('Plugin configuration: ', config)
 
   createModuleUsageMetric(instrumentationApi.agent)
@@ -142,7 +140,7 @@ function createPlugin(api, config = {}) {
               // try to treat as nested.
               const resolverSegment = instrumentationApi.createSegment(
                 `${RESOLVE_PREFIX}/${info.fieldName}`,
-                recordResolveSegment,
+                recordResolveSegment.bind(null, config),
                 operationSegment
               )
 
@@ -437,10 +435,11 @@ function getDeepestPathAndQueryArguments(definition) {
  * Creates metrics for resolver fields when transaction is ended.
  * This will record how long specific resolvers took.
  *
+ * @param {Object} params.config plugin config
  * @param {Object} segment relevant resolver segment
  * @param {string} scope name of transaction
  */
-function recordResolveSegment(segment, scope) {
+function recordResolveSegment(config, segment, scope) {
   const duration = segment.getDurationInMillis()
   const exclusive = segment.getExclusiveDurationInMillis()
 
@@ -448,22 +447,13 @@ function recordResolveSegment(segment, scope) {
 
   const attributes = segment.getAttributes()
   const fieldName = attributes[FIELD_NAME_ATTR]
+  const fieldType = attributes[PARENT_TYPE_ATTR]
 
   // The segment name uses the path to differentiate between duplicate
   // names resolving across different types. Here we use the field name
-  // without the path to compare resolver across usage and transactions.
-  if (fieldName) {
-    const fieldNameMetric = `${RESOLVE_PREFIX}/${fieldName}`
-    createMetricPairs(transaction, fieldNameMetric, scope, duration, exclusive)
-  }
-
-  const fieldType = attributes[PARENT_TYPE_ATTR]
-
-  // We therefore also record the field with typename. This can be
-  // helpful in case two field names happen to match but are scoped to
-  // different types.
-  if (fieldType) {
-    const typedFieldMetric = `${TYPED_RESOLVE_PREFIX}/${fieldType}.${fieldName}`
+  // with parent type to compare resolver across usage and transactions.
+  if (fieldName && fieldType) {
+    const typedFieldMetric = `${RESOLVE_PREFIX}/${fieldType}.${fieldName}`
     createMetricPairs(transaction, typedFieldMetric, scope, duration, exclusive)
   }
 }

--- a/lib/create-plugin.js
+++ b/lib/create-plugin.js
@@ -140,7 +140,7 @@ function createPlugin(api, config = {}) {
               // try to treat as nested.
               const resolverSegment = instrumentationApi.createSegment(
                 `${RESOLVE_PREFIX}/${info.fieldName}`,
-                recordResolveSegment.bind(null, config),
+                recordResolveSegment,
                 operationSegment
               )
 
@@ -439,7 +439,7 @@ function getDeepestPathAndQueryArguments(definition) {
  * @param {Object} segment relevant resolver segment
  * @param {string} scope name of transaction
  */
-function recordResolveSegment(config, segment, scope) {
+function recordResolveSegment(segment, scope) {
   const duration = segment.getDurationInMillis()
   const exclusive = segment.getExclusiveDurationInMillis()
 

--- a/tests/metrics-tests.js
+++ b/tests/metrics-tests.js
@@ -15,7 +15,6 @@ const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const FIELD_PREFIX = 'GraphQL/field/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 const ARG_PREFIX = 'GraphQL/arg/ApolloServer'
-const TYPED_RESOLVE_PREFIX = 'GraphQL/typedResolve/ApolloServer'
 
 module.exports = createMetricsTests
 
@@ -29,7 +28,7 @@ function createMetricsTests(captureFieldMetrics, t) {
 
     helper.agent.once('transactionFinished', () => {
       const operationPart = `query/${ANON_PLACEHOLDER}/hello`
-      const metrics = [`${OPERATION_PREFIX}/${operationPart}`, `${RESOLVE_PREFIX}/hello`]
+      const metrics = [`${OPERATION_PREFIX}/${operationPart}`, `${RESOLVE_PREFIX}/Query.hello`]
 
       if (captureFieldMetrics) {
         metrics.push(`${FIELD_PREFIX}/Query.hello`)
@@ -54,11 +53,7 @@ function createMetricsTests(captureFieldMetrics, t) {
 
     helper.agent.once('transactionFinished', () => {
       const operationPart = `query/${expectedName}/hello`
-      const metrics = [
-        `${OPERATION_PREFIX}/${operationPart}`,
-        `${RESOLVE_PREFIX}/hello`,
-        `${TYPED_RESOLVE_PREFIX}/Query.hello`
-      ]
+      const metrics = [`${OPERATION_PREFIX}/${operationPart}`, `${RESOLVE_PREFIX}/Query.hello`]
 
       if (captureFieldMetrics) {
         metrics.push(`${FIELD_PREFIX}/Query.hello`)
@@ -94,12 +89,9 @@ function createMetricsTests(captureFieldMetrics, t) {
 
       const metrics = [
         `${OPERATION_PREFIX}/${operationPart}`,
-        `${RESOLVE_PREFIX}/libraries`,
-        `${RESOLVE_PREFIX}/books`,
-        `${RESOLVE_PREFIX}/author`,
-        `${TYPED_RESOLVE_PREFIX}/Query.libraries`,
-        `${TYPED_RESOLVE_PREFIX}/Library.books`,
-        `${TYPED_RESOLVE_PREFIX}/Book.author`
+        `${RESOLVE_PREFIX}/Query.libraries`,
+        `${RESOLVE_PREFIX}/Library.books`,
+        `${RESOLVE_PREFIX}/Book.author`
       ]
 
       if (captureFieldMetrics) {
@@ -152,18 +144,14 @@ function createMetricsTests(captureFieldMetrics, t) {
 
       const operationMetrics1 = [
         `${OPERATION_PREFIX}/${operationPart1}`,
-        `${RESOLVE_PREFIX}/library`,
-        `${RESOLVE_PREFIX}/books`,
-        `${RESOLVE_PREFIX}/author`,
-        `${TYPED_RESOLVE_PREFIX}/Query.library`,
-        `${TYPED_RESOLVE_PREFIX}/Library.books`,
-        `${TYPED_RESOLVE_PREFIX}/Book.author`
+        `${RESOLVE_PREFIX}/Query.library`,
+        `${RESOLVE_PREFIX}/Library.books`,
+        `${RESOLVE_PREFIX}/Book.author`
       ]
 
       const operationMetrics2 = [
         `${OPERATION_PREFIX}/${operationPart2}`,
-        `${RESOLVE_PREFIX}/addThing`,
-        `${TYPED_RESOLVE_PREFIX}/Mutation.addThing`
+        `${RESOLVE_PREFIX}/Mutation.addThing`
       ]
 
       if (captureFieldMetrics) {
@@ -208,8 +196,7 @@ function createMetricsTests(captureFieldMetrics, t) {
       const operationPart = `query/${expectedName}/${path}`
       const operationMetrics = [
         `${OPERATION_PREFIX}/${operationPart}`,
-        `${RESOLVE_PREFIX}/${path}`,
-        `${TYPED_RESOLVE_PREFIX}/Query.${path}`
+        `${RESOLVE_PREFIX}/Query.${path}`
       ]
 
       if (captureFieldMetrics) {
@@ -246,12 +233,9 @@ function createMetricsTests(captureFieldMetrics, t) {
 
       const metrics = [
         `${OPERATION_PREFIX}/${operationPart}`,
-        `${RESOLVE_PREFIX}/libraries`,
-        `${RESOLVE_PREFIX}/books`,
-        `${RESOLVE_PREFIX}/author`,
-        `${TYPED_RESOLVE_PREFIX}/Query.libraries`,
-        `${TYPED_RESOLVE_PREFIX}/Library.books`,
-        `${TYPED_RESOLVE_PREFIX}/Book.author`
+        `${RESOLVE_PREFIX}/Query.libraries`,
+        `${RESOLVE_PREFIX}/Library.books`,
+        `${RESOLVE_PREFIX}/Book.author`
       ]
 
       if (captureFieldMetrics) {
@@ -331,12 +315,9 @@ function createMetricsTests(captureFieldMetrics, t) {
 
       const metrics = [
         `${OPERATION_PREFIX}/${operationPart}`,
-        `${RESOLVE_PREFIX}/library`,
-        `${RESOLVE_PREFIX}/books`,
-        `${RESOLVE_PREFIX}/author`,
-        `${TYPED_RESOLVE_PREFIX}/Query.library`,
-        `${TYPED_RESOLVE_PREFIX}/Library.books`,
-        `${TYPED_RESOLVE_PREFIX}/Book.author`
+        `${RESOLVE_PREFIX}/Query.library`,
+        `${RESOLVE_PREFIX}/Library.books`,
+        `${RESOLVE_PREFIX}/Book.author`
       ]
 
       if (captureFieldMetrics) {
@@ -386,12 +367,9 @@ function createMetricsTests(captureFieldMetrics, t) {
 
       const metrics = [
         `${OPERATION_PREFIX}/${operationPart}`,
-        `${RESOLVE_PREFIX}/library`,
-        `${RESOLVE_PREFIX}/books`,
-        `${RESOLVE_PREFIX}/author`,
-        `${TYPED_RESOLVE_PREFIX}/Query.library`,
-        `${TYPED_RESOLVE_PREFIX}/Library.books`,
-        `${TYPED_RESOLVE_PREFIX}/Book.author`
+        `${RESOLVE_PREFIX}/Query.library`,
+        `${RESOLVE_PREFIX}/Library.books`,
+        `${RESOLVE_PREFIX}/Book.author`
       ]
 
       if (captureFieldMetrics) {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes #283

## Details
We had complaints about producing very similar metrics.  You can still query what you need with this update that includes the parent type in all resolve metrics you just have to wildcard it.  This is a breaking change and is marked as such.
