### PR TITLE
test: Updated the version range for @apollo/gateway as it was finally stabilized.

### DIFF
--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -2,11 +2,6 @@
   "name": "apollo-server-tests",
   "version": "0.0.0",
   "private": true,
-  "//": [
-    "TODO: this is using latest as federation/gateway are not yet >=1.0 and ship with",
-    "breaking changes. Some versions of gateway do not play well with federation.",
-    "Update to proper version testing as federation and gateway modules stabilize."
-  ],
   "tests": [
     {
       "engines": {
@@ -14,8 +9,7 @@
       },
       "dependencies": {
         "@apollo/subgraph": "latest",
-        "@apollo/gateway": "latest",
-        "@opentelemetry/api": "latest",
+        "@apollo/gateway": ">=2.3.0",
         "apollo-server": "latest",
         "graphql": "latest"
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

We were only able to run against the latest of `@apollo/gateway` originally. This was because their verions were in 0.x and not aligned with other apollo deps. I found this is no longer the case.

## How to Test
```
npm run versioned:folder tests/versioned/apollo-federation
```

