### PR TITLE
chore: Limit depenendencies

### DIFF
--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -35,8 +35,8 @@
       "dependencies": {
         "@apollo/server": ">=4.0.0",
         "graphql": "16.6.0",
-        "body-parser": "latest",
-        "graphql-tag": "latest"
+        "body-parser": "1.20.3",
+        "graphql-tag": "2.12.6"
       },
       "files": [
         "transaction-naming.test.js",


### PR DESCRIPTION
Express has released new majors as of 2024-09-09. This PR fixes an issue where the latest version of `body-parser` causes a test failure. It also pins `graphql-tag` to avoid any potential similar issue in the future.

https://github.com/newrelic/node-newrelic/actions/runs/10791757204/job/29929879809?pr=2553
