### PR TITLE
test: Restored `graphql-tag` as it was not a transitive dep but instead a test dep

### DIFF
--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -31,7 +31,8 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@apollo/server": ">=4.0.0"
+        "@apollo/server": ">=4.0.0",
+        "graphql-tag": "latest"
       },
       "files": [
         "transaction-naming.test.js",

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -35,7 +35,8 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@apollo/server": ">=4.0.0"
+        "@apollo/server": ">=4.0.0",
+        "graphql-tag": "latest"
       },
       "files": [
         "transaction-naming.test.js",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
I thought `graphql-tag` was a transitive dep but it was not. The reason this works in the repo but not when the agent runs these tests is because we have `graphql-tag` as a dev dep in the root of this project.  


## How to test

I updated the agent locally

```sh
diff --git a/test/versioned-external/external-repos.js b/test/versioned-external/external-repos.js
index 396200a2f..2807cf412 100644
--- a/test/versioned-external/external-repos.js
+++ b/test/versioned-external/external-repos.js
@@ -14,8 +14,8 @@
 const repos = [
   {
     name: 'apollo-server',
-    repository: 'https://github.com/newrelic/newrelic-node-apollo-server-plugin.git',
-    branch: 'main',
+    repository: 'https://github.com/bizob2828/newrelic-node-apollo-server-plugin.git',
+    branch: 'restore-graphql-tag',
     additionalFiles: [
       'tests/agent-testing.js',
       'tests/create-apollo-server-setup.js',
```

Then ran `npm run versioned:external:major`


```sh
===============================================================
 ✓ apollo-federation (5) 14s
 ✓ apollo-server (14) 20s
 ✓ apollo-server-express (12) 19s
===============================================================
Versions executed

Folder: apollo-federation
	 * @apollo/subgraph(1): 2.9.1
	 * @apollo/gateway(1): 2.9.1
	 * apollo-server(1): 3.13.0
Folder: apollo-server-express
	 * apollo-server-express(1): 3.13.0
	 * @apollo/server(1): 4.11.0
	 * graphql-tag(1): 2.12.6
Folder: apollo-server
	 * apollo-server(1): 3.13.0
	 * @apollo/server(1): 4.11.0
	 * graphql-tag(1): 2.12.6
===============================================================
PASS
```
