### PR TITLE
test: Migrated `apollo-federation` versioned tests to `node:test`

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,6 +18,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 **[devDependencies](#devDependencies)**
 
 * [@apollo/server](#apolloserver)
+* [@matteo.collina/tspl](#matteocollinatspl)
 * [@newrelic/eslint-config](#newreliceslint-config)
 * [@newrelic/newrelic-oss-cli](#newrelicnewrelic-oss-cli)
 * [@newrelic/test-utilities](#newrelictest-utilities)
@@ -47,7 +48,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 
 ### @apollo/server
 
-This product includes source derived from [@apollo/server](https://github.com/apollographql/apollo-server) ([v4.10.3](https://github.com/apollographql/apollo-server/tree/v4.10.3)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v4.10.3/README.md):
+This product includes source derived from [@apollo/server](https://github.com/apollographql/apollo-server) ([v4.11.2](https://github.com/apollographql/apollo-server/tree/v4.11.2)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v4.11.2/README.md):
 
 ```
 MIT License
@@ -59,6 +60,35 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+### @matteo.collina/tspl
+
+This product includes source derived from [@matteo.collina/tspl](https://github.com/mcollina/tspl) ([v0.1.1](https://github.com/mcollina/tspl/tree/v0.1.1)), distributed under the [MIT License](https://github.com/mcollina/tspl/blob/v0.1.1/LICENSE):
+
+```
+MIT License
+
+Copyright (c) 2023 Matteo Collina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ```
 
 ### @newrelic/eslint-config
@@ -480,7 +510,7 @@ This product includes source derived from [@newrelic/newrelic-oss-cli](https://g
 
 ### @newrelic/test-utilities
 
-This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v8.5.0](https://github.com/newrelic/node-test-utilities/tree/v8.5.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v8.5.0/LICENSE):
+This product includes source derived from [@newrelic/test-utilities](https://github.com/newrelic/node-test-utilities) ([v8.7.0](https://github.com/newrelic/node-test-utilities/tree/v8.7.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-test-utilities/blob/v8.7.0/LICENSE):
 
 ```
                                  Apache License
@@ -876,7 +906,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.57.0](https://github.com/eslint/eslint/tree/v8.57.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.57.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v8.57.1](https://github.com/eslint/eslint/tree/v8.57.1)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v8.57.1/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -903,7 +933,7 @@ THE SOFTWARE.
 
 ### graphql
 
-This product includes source derived from [graphql](https://github.com/graphql/graphql-js) ([v16.8.1](https://github.com/graphql/graphql-js/tree/v16.8.1)), distributed under the [MIT License](https://github.com/graphql/graphql-js/blob/v16.8.1/LICENSE):
+This product includes source derived from [graphql](https://github.com/graphql/graphql-js) ([v16.9.0](https://github.com/graphql/graphql-js/tree/v16.9.0)), distributed under the [MIT License](https://github.com/graphql/graphql-js/blob/v16.9.0/LICENSE):
 
 ```
 MIT License
@@ -990,7 +1020,7 @@ SOFTWARE.
 
 ### lockfile-lint
 
-This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.13.2](https://github.com/lirantal/lockfile-lint/tree/v4.13.2)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.13.2/LICENSE):
+This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.14.0](https://github.com/lirantal/lockfile-lint/tree/v4.14.0)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.14.0/LICENSE):
 
 ```
 
@@ -1188,7 +1218,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v11.15.0](https://github.com/newrelic/node-newrelic/tree/v11.15.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v11.15.0/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v11.23.2](https://github.com/newrelic/node-newrelic/tree/v11.23.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v11.23.2/LICENSE):
 
 ```
                                  Apache License

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@apollo/server": "^4.1.1",
+    "@matteo.collina/tspl": "^0.1.1",
     "@newrelic/eslint-config": "^0.3.0",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/test-utilities": "^8.5.0",

--- a/tests/custom-assertions.js
+++ b/tests/custom-assertions.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+/**
+ * @param {TraceSegment} parent     Parent segment
+ * @param {Array} expected          Array of strings that represent segment names.
+ *                                  If an item in the array is another array, it
+ *                                  represents children of the previous item.
+ * @param {boolean} options.exact   If true, then the expected segments must match
+ *                                  exactly, including their position and children on all
+ *                                  levels.  When false, then only check that each child
+ *                                  exists.
+ * @param {array} options.exclude   Array of segment names that should be excluded from
+ *                                  validation.  This is useful, for example, when a
+ *                                  segment may or may not be created by code that is not
+ *                                  directly under test.  Only used when `exact` is true.
+ * @param {object} [deps] Injected dependencies.
+ * @param {object} [deps.assert] Assertion library to use.
+ */
+function assertSegments(parent, expected, options, { assert = require('node:assert') } = {}) {
+  let child
+  let childCount = 0
+
+  // rather default to what is more likely to fail than have a false test
+  let exact = true
+  if (options && options.exact === false) {
+    exact = options.exact
+  } else if (options === false) {
+    exact = false
+  }
+
+  function getChildren(_parent) {
+    return _parent.children.filter(function (item) {
+      if (exact && options && options.exclude) {
+        return options.exclude.indexOf(item.name) === -1
+      }
+      return true
+    })
+  }
+
+  const children = getChildren(parent)
+  if (exact) {
+    for (let i = 0; i < expected.length; ++i) {
+      const sequenceItem = expected[i]
+
+      if (typeof sequenceItem === 'string') {
+        child = children[childCount++]
+        assert.equal(
+          child ? child.name : undefined,
+          sequenceItem,
+          'segment "' +
+            parent.name +
+            '" should have child "' +
+            sequenceItem +
+            '" in position ' +
+            childCount
+        )
+
+        // If the next expected item is not array, then check that the current
+        // child has no children
+        if (!Array.isArray(expected[i + 1])) {
+          assert.ok(
+            getChildren(child).length === 0,
+            'segment "' + child.name + '" should not have any children'
+          )
+        }
+      } else if (typeof sequenceItem === 'object') {
+        assertSegments(child, sequenceItem, options, { assert })
+      }
+    }
+
+    // check if correct number of children was found
+    assert.equal(children.length, childCount)
+  } else {
+    for (let i = 0; i < expected.length; i++) {
+      const sequenceItem = expected[i]
+
+      if (typeof sequenceItem === 'string') {
+        // find corresponding child in parent
+        for (let j = 0; j < parent.children.length; j++) {
+          if (parent.children[j].name === sequenceItem) {
+            child = parent.children[j]
+          }
+        }
+        assert.ok(child, 'segment "' + parent.name + '" should have child "' + sequenceItem + '"')
+        if (typeof expected[i + 1] === 'object') {
+          assertSegments(child, expected[i + 1], { exact }, { assert })
+        }
+      }
+    }
+  }
+}
+
+module.exports = {
+  assertSegments
+}

--- a/tests/versioned/apollo-federation/query-obfuscation.test.js
+++ b/tests/versioned/apollo-federation/query-obfuscation.test.js
@@ -4,34 +4,28 @@
  */
 
 'use strict'
-
-const { setupFederatedGatewayServerTests } = require('./federated-gateway-server-setup')
-
+const test = require('node:test')
+const assert = require('node:assert')
+const { setupFederatedGateway, teardownGateway } = require('./federated-gateway-server-setup')
 const { executeQuery } = require('../../test-client')
 const { checkResult } = require('../common')
-
 const SEGMENT_DESTINATION = 0x20
-
 const ANON_PLACEHOLDER = '<anonymous>'
-
 const QUERY_ATTRIBUTE_NAME = 'graphql.operation.query'
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer/query'
 
-setupFederatedGatewayServerTests({
-  suiteName: 'query obfuscation',
-  createTests: createQueryObfuscaionTests
-})
+test('apollo-federation: query obfuscation', async (t) => {
+  t.beforeEach(async (ctx) => {
+    await setupFederatedGateway({ ctx })
+  })
 
-/**
- * Creates a set of standard transction tests to run against various
- * apollo-server libraries.
- * It is required that t.context.helper and t.context.serverUrl are set.
- * @param {*} t a tap test instance
- */
-function createQueryObfuscaionTests(t) {
-  const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer/query'
+  t.afterEach((ctx) => {
+    teardownGateway({ ctx })
+  })
 
-  t.test('Obfuscates query arguments', (t) => {
-    const { helper, serverUrl } = t.context
+  await t.test('Obfuscates query arguments', (t, end) => {
+    const { helper, gatewayService } = t.nr
+    const serverUrl = gatewayService.url
 
     const query = `query {
       library(id: 3) {
@@ -43,26 +37,28 @@ function createQueryObfuscaionTests(t) {
 
     const path = 'library.booksInStock.title'
 
+    let tx
     helper.agent.on('transactionFinished', (transaction) => {
+      tx = transaction
+    })
+
+    executeQuery(serverUrl, query, (err, result) => {
+      assert.ok(!err)
       const operationName = `${OPERATION_PREFIX}/${ANON_PLACEHOLDER}/${path}`
-      const operationSegment = findSegmentByName(transaction.trace.root, operationName)
+      const operationSegment = findSegmentByName(tx.trace.root, operationName)
 
       // only test one operation segment of three federated server transactions
       if (operationSegment) {
         const operationAttributes = operationSegment.attributes.get(SEGMENT_DESTINATION)
 
-        t.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('library(***)') > 0)
+        assert.ok(operationAttributes[QUERY_ATTRIBUTE_NAME].includes('library(***)') > 0)
       }
-    })
-
-    executeQuery(serverUrl, query, (err, result) => {
-      t.error(err)
-      checkResult(t, result, () => {
-        t.end()
+      checkResult(assert, result, () => {
+        end()
       })
     })
   })
-}
+})
 
 function findSegmentByName(root, name) {
   if (root.name === name) {

--- a/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
+++ b/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
@@ -33,7 +33,7 @@ test(
   'Capture/Ignore Service Definition and Health Check ' +
     'query transaction from sub-graph servers',
   async (t) => {
-    await t.test('Should ignore Service Definiion query by default', async (t) => {
+    await t.test('Should ignore Service Definition query by default', async (t) => {
       const pluginConfig = {}
       const { helper, apollo, services, plugins, libraryServer } = await setup(pluginConfig)
       const ignore = true

--- a/tests/versioned/apollo-federation/transaction-naming.test.js
+++ b/tests/versioned/apollo-federation/transaction-naming.test.js
@@ -4,30 +4,27 @@
  */
 
 'use strict'
-
+const test = require('node:test')
+const assert = require('node:assert')
 const { executeQuery, executeQueryBatch } = require('../../test-client')
-
 const ANON_PLACEHOLDER = '<anonymous>'
-
-const { setupFederatedGatewayServerTests } = require('./federated-gateway-server-setup')
+const { setupFederatedGateway, teardownGateway } = require('./federated-gateway-server-setup')
 const { checkResult, shouldSkipTransaction } = require('../common')
 
-setupFederatedGatewayServerTests({
-  suiteName: 'federated transaction names',
-  createTests: createFederatedTransactionNamingTests
-})
+test('apollo-federation: transaction names', async (t) => {
+  t.beforeEach(async (ctx) => {
+    await setupFederatedGateway({ ctx })
+  })
 
-/**
- * Creates a set of standard transaction naming tests to run
- * against express-based apollo-server libraries.
- * It is required that t.context.helper and t.context.serverUrl are set.
- * @param {*} t a tap test instance
- */
-function createFederatedTransactionNamingTests(t, frameworkName) {
-  const TRANSACTION_PREFIX = `WebTransaction/${frameworkName}/POST`
+  t.afterEach((ctx) => {
+    teardownGateway({ ctx })
+  })
 
-  t.test('anonymous query, multi selections should return deepest unique path', (t) => {
-    const { helper, serverUrl } = t.context
+  const TRANSACTION_PREFIX = `WebTransaction/Expressjs/POST`
+
+  await t.test('anonymous query, multi selections should return deepest unique path', (t, end) => {
+    const { helper, gatewayService } = t.nr
+    const serverUrl = gatewayService.url
 
     const query = `query {
       libraries {
@@ -44,25 +41,27 @@ function createFederatedTransactionNamingTests(t, frameworkName) {
       }
     }`
 
+    const operationPart = `query/${ANON_PLACEHOLDER}/libraries`
+    let tx
+
     helper.agent.on('transactionFinished', (transaction) => {
       if (shouldSkipTransaction(transaction)) {
         return
       }
-
-      const operationPart = `query/${ANON_PLACEHOLDER}/libraries`
-      t.equal(transaction.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      tx = transaction
     })
 
     executeQuery(serverUrl, query, (err, result) => {
-      t.error(err)
-      checkResult(t, result, () => {
-        t.end()
+      assert.equal(tx.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      checkResult(assert, result, () => {
+        end()
       })
     })
   })
 
-  t.test('anonymous query, single selections should return deepest unique path', (t) => {
-    const { helper, serverUrl } = t.context
+  await t.test('anonymous query, single selections should return deepest unique path', (t, end) => {
+    const { helper, gatewayService } = t.nr
+    const serverUrl = gatewayService.url
 
     const query = `query {
       libraries {
@@ -72,25 +71,27 @@ function createFederatedTransactionNamingTests(t, frameworkName) {
       }
     }`
 
+    const operationPart = `query/${ANON_PLACEHOLDER}/libraries.booksInStock.title`
+    let tx
     helper.agent.on('transactionFinished', (transaction) => {
       if (shouldSkipTransaction(transaction)) {
         return
       }
-
-      const operationPart = `query/${ANON_PLACEHOLDER}/libraries.booksInStock.title`
-      t.equal(transaction.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      tx = transaction
     })
 
     executeQuery(serverUrl, query, (err, result) => {
-      t.error(err)
-      checkResult(t, result, () => {
-        t.end()
+      assert.equal(tx.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      assert.ok(!err)
+      checkResult(assert, result, () => {
+        end()
       })
     })
   })
 
-  t.test('named query, multi selections should return deepest unique path', (t) => {
-    const { helper, serverUrl } = t.context
+  await t.test('named query, multi selections should return deepest unique path', (t, end) => {
+    const { helper, gatewayService } = t.nr
+    const serverUrl = gatewayService.url
 
     const query = `query booksInStock {
       libraries {
@@ -102,25 +103,28 @@ function createFederatedTransactionNamingTests(t, frameworkName) {
       }
     }`
 
+    const operationPart = 'query/booksInStock/libraries'
+    let tx
+
     helper.agent.on('transactionFinished', (transaction) => {
       if (shouldSkipTransaction(transaction)) {
         return
       }
-
-      const operationPart = 'query/booksInStock/libraries'
-      t.equal(transaction.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      tx = transaction
     })
 
     executeQuery(serverUrl, query, (err, result) => {
-      t.error(err)
-      checkResult(t, result, () => {
-        t.end()
+      assert.equal(tx.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      assert.ok(!err)
+      checkResult(assert, result, () => {
+        end()
       })
     })
   })
 
-  t.test('named query, single selections should return deepest unique path', (t) => {
-    const { helper, serverUrl } = t.context
+  await t.test('named query, single selections should return deepest unique path', (t, end) => {
+    const { helper, gatewayService } = t.nr
+    const serverUrl = gatewayService.url
 
     const query = `query booksInStock {
       libraries {
@@ -130,25 +134,28 @@ function createFederatedTransactionNamingTests(t, frameworkName) {
       }
     }`
 
+    const operationPart = 'query/booksInStock/libraries.booksInStock.title'
+    let tx
+
     helper.agent.on('transactionFinished', (transaction) => {
       if (shouldSkipTransaction(transaction)) {
         return
       }
-
-      const operationPart = 'query/booksInStock/libraries.booksInStock.title'
-      t.equal(transaction.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      tx = transaction
     })
 
     executeQuery(serverUrl, query, (err, result) => {
-      t.error(err)
-      checkResult(t, result, () => {
-        t.end()
+      assert.equal(tx.name, `${TRANSACTION_PREFIX}//${operationPart}`)
+      assert.ok(!err)
+      checkResult(assert, result, () => {
+        end()
       })
     })
   })
 
-  t.test('should properly name transaction when a named, batch federated query', (t) => {
-    const { helper, serverUrl } = t.context
+  await t.test('should properly name transaction when a named, batch federated query', (t, end) => {
+    const { helper, gatewayService } = t.nr
+    const serverUrl = gatewayService.url
 
     const booksQueryName = 'GetBooksForLibraries'
     const booksQuery = `query ${booksQueryName} {
@@ -173,25 +180,27 @@ function createFederatedTransactionNamingTests(t, frameworkName) {
 
     const queries = [booksQuery, magazineQuery]
 
+    const operationPart1 = `query/${booksQueryName}/libraries.booksInStock`
+    const operationPart2 = `query/${magazineQueryName}/libraries.magazinesInStock`
+
+    const batchTransactionPrefix = `${TRANSACTION_PREFIX}//batch`
+    let tx
+
     helper.agent.on('transactionFinished', (transaction) => {
       if (shouldSkipTransaction(transaction)) {
         return
       }
-      const operationPart1 = `query/${booksQueryName}/libraries.booksInStock`
-      const operationPart2 = `query/${magazineQueryName}/libraries.magazinesInStock`
-
-      const batchTransactionPrefix = `${TRANSACTION_PREFIX}//batch`
-
-      t.equal(transaction.name, `${batchTransactionPrefix}/${operationPart1}/${operationPart2}`)
+      tx = transaction
     })
 
     executeQueryBatch(serverUrl, queries, (err, result) => {
-      t.error(err)
-      checkResult(t, result, () => {
-        t.equal(result.length, 2)
+      assert.equal(tx.name, `${batchTransactionPrefix}/${operationPart1}/${operationPart2}`)
+      assert.ok(!err)
+      checkResult(assert, result, () => {
+        assert.equal(result.length, 2)
 
-        t.end()
+        end()
       })
     })
   })
-}
+})

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -10,12 +10,12 @@ const common = module.exports
  * Verify we didn't break anything outright and
  * test is setup correctly for functioning calls.
  */
-common.checkResult = function checkResult(t, result, callback) {
-  t.ok(result)
+common.checkResult = function checkResult(assert, result, callback) {
+  assert.ok(result)
 
   if (result.errors) {
     result.errors.forEach((error) => {
-      t.error(error)
+      assert.ok(!error)
     })
   }
 

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Nov 26 2024 12:17:31 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Mon Dec 02 2024 17:33:20 GMT-0500 (Eastern Standard Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -7,18 +7,31 @@
   "includeDev": true,
   "dependencies": {},
   "devDependencies": {
-    "@apollo/server@4.10.3": {
+    "@apollo/server@4.11.2": {
       "name": "@apollo/server",
-      "version": "4.10.3",
+      "version": "4.11.2",
       "range": "^4.1.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/apollographql/apollo-server",
-      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v4.10.3",
+      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v4.11.2",
       "licenseFile": "node_modules/@apollo/server/README.md",
-      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v4.10.3/README.md",
+      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v4.11.2/README.md",
       "licenseTextSource": "spdx",
       "publisher": "Apollo",
       "email": "packages@apollographql.com"
+    },
+    "@matteo.collina/tspl@0.1.1": {
+      "name": "@matteo.collina/tspl",
+      "version": "0.1.1",
+      "range": "^0.1.1",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/mcollina/tspl",
+      "versionedRepoUrl": "https://github.com/mcollina/tspl/tree/v0.1.1",
+      "licenseFile": "node_modules/@matteo.collina/tspl/LICENSE",
+      "licenseUrl": "https://github.com/mcollina/tspl/blob/v0.1.1/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Matteo Collina",
+      "email": "hello@matteocollina.com"
     },
     "@newrelic/eslint-config@0.3.0": {
       "name": "@newrelic/eslint-config",
@@ -45,15 +58,15 @@
       "licenseTextSource": "file",
       "publisher": "New Relic"
     },
-    "@newrelic/test-utilities@8.5.0": {
+    "@newrelic/test-utilities@8.7.0": {
       "name": "@newrelic/test-utilities",
-      "version": "8.5.0",
+      "version": "8.7.0",
       "range": "^8.5.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-test-utilities",
-      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v8.5.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-test-utilities/tree/v8.7.0",
       "licenseFile": "node_modules/@newrelic/test-utilities/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v8.5.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-test-utilities/blob/v8.7.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
@@ -145,28 +158,28 @@
       "licenseTextSource": "file",
       "publisher": "Teddy Katz"
     },
-    "eslint@8.57.0": {
+    "eslint@8.57.1": {
       "name": "eslint",
-      "version": "8.57.0",
+      "version": "8.57.1",
       "range": "^8.24.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.57.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v8.57.1",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.57.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v8.57.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"
     },
-    "graphql@16.8.1": {
+    "graphql@16.9.0": {
       "name": "graphql",
-      "version": "16.8.1",
+      "version": "16.9.0",
       "range": "^16.6.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/graphql/graphql-js",
-      "versionedRepoUrl": "https://github.com/graphql/graphql-js/tree/v16.8.1",
+      "versionedRepoUrl": "https://github.com/graphql/graphql-js/tree/v16.9.0",
       "licenseFile": "node_modules/graphql/LICENSE",
-      "licenseUrl": "https://github.com/graphql/graphql-js/blob/v16.8.1/LICENSE",
+      "licenseUrl": "https://github.com/graphql/graphql-js/blob/v16.9.0/LICENSE",
       "licenseTextSource": "file"
     },
     "husky@6.0.0": {
@@ -195,29 +208,29 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "lockfile-lint@4.13.2": {
+    "lockfile-lint@4.14.0": {
       "name": "lockfile-lint",
-      "version": "4.13.2",
+      "version": "4.14.0",
       "range": "^4.9.6",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/lirantal/lockfile-lint",
-      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.13.2",
+      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.14.0",
       "licenseFile": "node_modules/lockfile-lint/LICENSE",
-      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.13.2/LICENSE",
+      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.14.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Liran Tal",
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@11.15.0": {
+    "newrelic@11.23.2": {
       "name": "newrelic",
-      "version": "11.15.0",
-      "range": "^11.5.0",
+      "version": "11.23.2",
+      "range": "^11.15.0",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v11.15.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v11.23.2",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v11.15.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v11.23.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Migrated apollo-federation tests to `node:test`. This was more than just updating to use assert and `node:test`. I found that we were asserting in `transactionFinished` which was catching errors on assertions. I use transactionFinished to save a reference to the transaction and do the assertion after the graphql http request is over. This allows for tests to fail when assertions do. Also I changed our helper to have an init and teardown that gets called in every suite to make it easier to diagnose. Lastly, I copied our `assertSegments` helper from agent which required me to update howe we assert the segment tree.

## How to Test

```sh
npm run versioned:folder tests/versioned/apollo-federation
```

## Related Issues
Closes #328