### PR TITLE
test: Updated `apollo-federation` tests to use `@apollo/server`

### DIFF
--- a/tests/versioned/apollo-federation/package.json
+++ b/tests/versioned/apollo-federation/package.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@apollo/subgraph": "latest",
         "@apollo/gateway": ">=2.3.0",
-        "apollo-server": "latest"
+        "@apollo/server": "latest",
+        "graphql-tag": "latest"
       },
       "files": [
         "segments.test.js",

--- a/tests/versioned/apollo-federation/query-obfuscation.test.js
+++ b/tests/versioned/apollo-federation/query-obfuscation.test.js
@@ -19,8 +19,8 @@ test('apollo-federation: query obfuscation', async (t) => {
     await setupFederatedGateway({ ctx })
   })
 
-  t.afterEach((ctx) => {
-    teardownGateway({ ctx })
+  t.afterEach(async (ctx) => {
+    await teardownGateway({ ctx })
   })
 
   await t.test('Obfuscates query arguments', (t, end) => {

--- a/tests/versioned/apollo-federation/segments.test.js
+++ b/tests/versioned/apollo-federation/segments.test.js
@@ -22,12 +22,12 @@ test('apollo-federation: federated segments', async (t) => {
     await setupFederatedGateway({ ctx })
   })
 
-  t.afterEach((ctx) => {
-    teardownGateway({ ctx })
+  t.afterEach(async (ctx) => {
+    await teardownGateway({ ctx })
   })
 
   await t.test('should nest sub graphs under operation', async (t) => {
-    const plan = tspl(t, { plan: 9 })
+    const plan = tspl(t, { plan: 8 })
     const { helper, gatewayService, libraryService, magazineService, bookService } = t.nr
     const serverUrl = gatewayService.url
 
@@ -64,13 +64,10 @@ test('apollo-federation: federated segments', async (t) => {
       const expectedSegments = [
         `${TRANSACTION_PREFIX}//${operationPart}`,
         [
-          'Expressjs/Router: /',
+          'Nodejs/Middleware/Expressjs/<anonymous>',
           [
-            'Nodejs/Middleware/Expressjs/<anonymous>',
-            [
-              `${OPERATION_PREFIX}/${operationPart}`,
-              [libraryExternal, bookExternal, magazineExternal]
-            ]
+            `${OPERATION_PREFIX}/${operationPart}`,
+            [libraryExternal, bookExternal, magazineExternal]
           ]
         ]
       ]
@@ -82,7 +79,7 @@ test('apollo-federation: federated segments', async (t) => {
   })
 
   await t.test('batch query should nest sub graphs under appropriate operations', async (t) => {
-    const plan = tspl(t, { plan: 12 })
+    const plan = tspl(t, { plan: 11 })
     const { helper, gatewayService, libraryService, bookService, magazineService } = t.nr
     const serverUrl = gatewayService.url
 
@@ -134,15 +131,12 @@ test('apollo-federation: federated segments', async (t) => {
       const expectedSegments = [
         `${batchTransactionPrefix}/${expectedQuery1Name}/${expectedQuery2Name}`,
         [
-          'Expressjs/Router: /',
+          'Nodejs/Middleware/Expressjs/<anonymous>',
           [
-            'Nodejs/Middleware/Expressjs/<anonymous>',
-            [
-              `${OPERATION_PREFIX}/${operationPart1}`,
-              [libraryExternal, bookExternal],
-              `${OPERATION_PREFIX}/${operationPart2}`,
-              [libraryExternal, magazineExternal]
-            ]
+            `${OPERATION_PREFIX}/${operationPart1}`,
+            [libraryExternal, bookExternal],
+            `${OPERATION_PREFIX}/${operationPart2}`,
+            [libraryExternal, magazineExternal]
           ]
         ]
       ]

--- a/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
+++ b/tests/versioned/apollo-federation/service-definition-and-healthcheck-filtering.test.js
@@ -20,13 +20,15 @@ async function setup(pluginConfig) {
   const plugins = [instrumentationPlugin]
 
   // Do after instrumentation to ensure express isn't loaded too soon.
-  const apollo = require('apollo-server')
+  const { ApolloServer } = require('@apollo/server')
+  const gql = require('graphql-tag')
+  const { startStandaloneServer } = require('@apollo/server/standalone')
 
-  const libraryService = await loadLibraries(apollo, plugins)
+  const libraryService = await loadLibraries({ ApolloServer, startStandaloneServer, gql, plugins })
   const libraryServer = libraryService.server
 
   const services = [{ name: libraryService.name, url: libraryService.url }]
-  return { apollo, helper, plugins, services, libraryServer }
+  return { ApolloServer, gql, startStandaloneServer, helper, plugins, services, libraryServer }
 }
 
 test(
@@ -35,7 +37,8 @@ test(
   async (t) => {
     await t.test('Should ignore Service Definition query by default', async (t) => {
       const pluginConfig = {}
-      const { helper, apollo, services, plugins, libraryServer } = await setup(pluginConfig)
+      const { helper, ApolloServer, gql, startStandaloneServer, services, plugins, libraryServer } =
+        await setup(pluginConfig)
       const ignore = true
 
       let tx
@@ -43,11 +46,16 @@ test(
         tx = transaction
       })
 
-      const gatewayService = await loadGateway(apollo, services, plugins)
-      t.after(() => {
+      const gatewayService = await loadGateway({
+        ApolloServer,
+        gql,
+        startStandaloneServer,
+        services,
+        plugins
+      })
+      t.after(async () => {
         helper.unload()
-        libraryServer.stop()
-        gatewayService.server.stop()
+        await Promise.all([libraryServer.stop(), gatewayService.server.stop()])
       })
       assert.equal(tx.ignore, ignore, `should set transaction.ignore to ${ignore}`)
     })
@@ -59,7 +67,15 @@ test(
         const pluginConfig = {
           captureServiceDefinitionQueries: true
         }
-        const { helper, apollo, services, plugins, libraryServer } = await setup(pluginConfig)
+        const {
+          helper,
+          ApolloServer,
+          gql,
+          startStandaloneServer,
+          services,
+          plugins,
+          libraryServer
+        } = await setup(pluginConfig)
         const ignore = false
 
         let tx
@@ -67,11 +83,16 @@ test(
           tx = transaction
         })
 
-        const gatewayService = await loadGateway(apollo, services, plugins)
-        t.after(() => {
+        const gatewayService = await loadGateway({
+          ApolloServer,
+          gql,
+          startStandaloneServer,
+          services,
+          plugins
+        })
+        t.after(async () => {
           helper.unload()
-          libraryServer.stop()
-          gatewayService.server.stop()
+          await Promise.all([libraryServer.stop(), gatewayService.server.stop()])
         })
         assert.equal(tx.ignore, ignore, `should set transaction.ignore to ${ignore}`)
       }
@@ -79,7 +100,8 @@ test(
 
     await t.test('Should ignore Health Check query by default', async (t) => {
       const pluginConfig = {}
-      const { helper, apollo, services, plugins, libraryServer } = await setup(pluginConfig)
+      const { helper, ApolloServer, gql, startStandaloneServer, services, plugins, libraryServer } =
+        await setup(pluginConfig)
       const ignore = true
 
       let tx
@@ -89,11 +111,16 @@ test(
         }
       })
 
-      const gatewayService = await loadGateway(apollo, services, plugins)
-      t.after(() => {
+      const gatewayService = await loadGateway({
+        ApolloServer,
+        gql,
+        startStandaloneServer,
+        services,
+        plugins
+      })
+      t.after(async () => {
         helper.unload()
-        libraryServer.stop()
-        gatewayService.server.stop()
+        await Promise.all([libraryServer.stop(), gatewayService.server.stop()])
       })
 
       // trigger the healthcheck
@@ -107,7 +134,15 @@ test(
         const pluginConfig = {
           captureHealthCheckQueries: true
         }
-        const { helper, apollo, services, plugins, libraryServer } = await setup(pluginConfig)
+        const {
+          helper,
+          ApolloServer,
+          gql,
+          startStandaloneServer,
+          services,
+          plugins,
+          libraryServer
+        } = await setup(pluginConfig)
         const ignore = false
 
         let tx
@@ -117,11 +152,16 @@ test(
           }
         })
 
-        const gatewayService = await loadGateway(apollo, services, plugins)
-        t.after(() => {
+        const gatewayService = await loadGateway({
+          ApolloServer,
+          gql,
+          startStandaloneServer,
+          services,
+          plugins
+        })
+        t.after(async () => {
           helper.unload()
-          libraryServer.stop()
-          gatewayService.server.stop()
+          await Promise.all([libraryServer.stop(), gatewayService.server.stop()])
         })
 
         // trigger the healthcheck

--- a/tests/versioned/apollo-federation/sub-graph-transactions.test.js
+++ b/tests/versioned/apollo-federation/sub-graph-transactions.test.js
@@ -15,8 +15,8 @@ test('apollo-federation: sub graph transaction naming ', async (t) => {
     await setupFederatedGateway({ ctx, instrumentSubGraphs: true })
   })
 
-  t.afterEach((ctx) => {
-    teardownGateway({ ctx })
+  t.afterEach(async (ctx) => {
+    await teardownGateway({ ctx })
   })
 
   await t.test('should properly name when inline fragments exist', (t, end) => {

--- a/tests/versioned/apollo-federation/transaction-naming.test.js
+++ b/tests/versioned/apollo-federation/transaction-naming.test.js
@@ -16,8 +16,8 @@ test('apollo-federation: transaction names', async (t) => {
     await setupFederatedGateway({ ctx })
   })
 
-  t.afterEach((ctx) => {
-    teardownGateway({ ctx })
+  t.afterEach(async (ctx) => {
+    await teardownGateway({ ctx })
   })
 
   const TRANSACTION_PREFIX = `WebTransaction/Expressjs/POST`


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
After refactoring these tests it was easier to pin down why I couldn't migrate this months ago.  This PR updates the federated versioned tests to use apollo v4.

## How to Test

```sh
npm run versioned:folder tests/versioned/apollo-federation
```

## Related Issues
Closes #324
