### PR TITLE
fix: Updated plugin to pass in transaction trace to properly calculate the exclusive time of operation and resolver segments

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1217,7 +1217,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v11.23.2](https://github.com/newrelic/node-newrelic/tree/v11.23.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v11.23.2/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v12.18.2](https://github.com/newrelic/node-newrelic/tree/v12.18.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v12.18.2/LICENSE):
 
 ```
                                  Apache License

--- a/lib/common.js
+++ b/lib/common.js
@@ -86,7 +86,7 @@ function createResolverSegment({ shim, parent, resolver, formattedPath }) {
  */
 function recordResolveSegment(segment, scope, transaction) {
   const duration = segment.getDurationInMillis()
-  const exclusive = segment.getExclusiveDurationInMillis()
+  const exclusive = segment.getExclusiveDurationInMillis(transaction?.trace)
 
   const attributes = segment.getAttributes()
   const fieldName = attributes[FIELD_NAME_ATTR]
@@ -103,7 +103,7 @@ function recordResolveSegment(segment, scope, transaction) {
 
 function recordOperationSegment(segment, scope, transaction) {
   const duration = segment.getDurationInMillis()
-  const exclusive = segment.getExclusiveDurationInMillis()
+  const exclusive = segment.getExclusiveDurationInMillis(transaction?.trace)
 
   createMetricPairs(transaction, segment.name, scope, duration, exclusive)
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "lockfile-lint": "^4.9.6",
-    "newrelic": "^12.11.0",
+    "newrelic": "^12.18.2",
     "prettier": "^2.3.2",
     "sinon": "^11.1.2",
     "tsd": "^0.18.0"

--- a/tests/versioned/apollo-server/segments.test.js
+++ b/tests/versioned/apollo-server/segments.test.js
@@ -6,10 +6,16 @@
 'use strict'
 
 const test = require('node:test')
-
+const promiseResolvers = require('../../lib/promise-resolvers')
+const { executeQuery } = require('../../lib/test-client')
 const { afterEach, setupCoreTest } = require('../../lib/test-tools')
+const { checkResult, baseSegment } = require('../common')
+const assert = require('node:assert')
 
 const expressSegmentsTests = require('../express-segments-tests')
+const { assertSegments, assertMetrics } = require('../../lib/custom-assertions')
+const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
+const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
 
 test.afterEach(async (ctx) => {
   await afterEach({ t: ctx, testDir: __dirname })
@@ -31,3 +37,56 @@ for (const scalarTest of expressSegmentsTests.tests) {
     await scalarTest.fn(t)
   })
 }
+
+test('fragmented trace does not add segments to trace but still records metrics for operation/resolver actions', async (t) => {
+  // set the max_trace_segments to 7 to exclude capturing the operation and resolver segments as part of tx trace
+  // see: https://github.com/newrelic/newrelic-node-apollo-server-plugin/issues/344
+  await setupCoreTest({ t, testDir: __dirname, agentConfig: { max_trace_segments: 7 } })
+  const {
+    helper,
+    serverUrl,
+    apolloServerPkg: { isApollo4 }
+  } = t.nr
+  const { promise, resolve } = promiseResolvers()
+  const expectedName = 'testQuery'
+  const query = `query ${expectedName} {
+    libraries {
+      books {
+        title
+        author {
+          name
+        }
+      }
+    }
+  }`
+
+  const path = 'libraries.books'
+
+  helper.agent.once('transactionFinished', (transaction) => {
+    const operationPart = `query/${expectedName}/${path}`
+    const firstSegmentName = baseSegment(operationPart, 'WebTransaction/Expressjs/POST')
+    const expectedSegments = [firstSegmentName]
+    if (isApollo4) {
+      expectedSegments.push(['Nodejs/Middleware/Expressjs/<anonymous>'])
+    } else {
+      expectedSegments.push(['Expressjs/Router: /'])
+    }
+    assertSegments(transaction.trace, transaction.trace.root, expectedSegments, { exact: false })
+
+    const expectedMetrics = [
+      [{ name: `${OPERATION_PREFIX}/${operationPart}` }],
+      [{ name: `${RESOLVE_PREFIX}/Query.libraries` }],
+      [{ name: `${RESOLVE_PREFIX}/Library.books` }],
+      [{ name: `${RESOLVE_PREFIX}/Book.author` }]
+    ]
+
+    assertMetrics(transaction.metrics, expectedMetrics)
+  })
+
+  executeQuery(serverUrl, query, (err, result) => {
+    assert.ifError(err)
+    checkResult(assert, result, resolve)
+  })
+
+  await promise
+})

--- a/tests/versioned/common.js
+++ b/tests/versioned/common.js
@@ -29,3 +29,26 @@ common.checkResult = function checkResult(assert, result, callback) {
 common.shouldSkipTransaction = function shouldSkipTransaction(transaction) {
   return !!transaction.forceIgnore
 }
+
+/**
+ * Creates the root segment based on a prefix and operation part
+ */
+common.baseSegment = function baseSegment(operationPart, prefix) {
+  return `${prefix}//${operationPart}`
+}
+
+/**
+ * Creates the appropriate sibling hierarchy of segments
+ * In apollo 4 they tweaked how the apollo server express instance is constructed.
+ * It lacks a / router and routes everything through a global middleware
+ */
+common.constructSegments = function constructSegments(
+  firstSegmentName,
+  operationSegments,
+  isApollo4
+) {
+  if (isApollo4) {
+    return [firstSegmentName, [...operationSegments]]
+  }
+  return [firstSegmentName, ['Expressjs/Router: /', [...operationSegments]]]
+}

--- a/tests/versioned/express-segments-tests.js
+++ b/tests/versioned/express-segments-tests.js
@@ -8,7 +8,7 @@
 const assert = require('node:assert')
 
 const { executeQuery, executeQueryBatch } = require('../lib/test-client')
-const { checkResult } = require('./common')
+const { checkResult, baseSegment, constructSegments } = require('./common')
 const { assertSegments } = require('../lib/custom-assertions')
 const promiseResolvers = require('../lib/promise-resolvers')
 
@@ -16,25 +16,6 @@ const ANON_PLACEHOLDER = '<anonymous>'
 const UNKNOWN_OPERATION = '<unknown>'
 const OPERATION_PREFIX = 'GraphQL/operation/ApolloServer'
 const RESOLVE_PREFIX = 'GraphQL/resolve/ApolloServer'
-
-/**
- * Creates the root segment based on a prefix and operation part
- */
-function baseSegment(operationPart, prefix) {
-  return `${prefix}//${operationPart}`
-}
-
-/**
- * Creates the appropriate sibling hierarchy of segments
- * In apollo 4 they tweaked how the apollo server express instance is constructed.
- * It lacks a / router and routes everything through a global middleware
- */
-function constructSegments(firstSegmentName, operationSegments, isApollo4) {
-  if (isApollo4) {
-    return [firstSegmentName, [...operationSegments]]
-  }
-  return [firstSegmentName, ['Expressjs/Router: /', [...operationSegments]]]
-}
 
 const tests = []
 

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Jan 14 2025 15:09:50 GMT-0500 (Eastern Standard Time)",
+  "lastUpdated": "Tue May 06 2025 13:18:28 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -222,15 +222,15 @@
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@11.23.2": {
+    "newrelic@12.18.2": {
       "name": "newrelic",
-      "version": "11.23.2",
-      "range": "^12.11.0",
+      "version": "12.18.2",
+      "range": "^12.18.2",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v11.23.2",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v12.18.2",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v11.23.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v12.18.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md

Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description
When this plugin was updated post 12.11.0, we missed passing in `trace` to `segment.getExclusiveDurationInMillis()`. It appears that was because the segments already had exclusive durations calculated when the transaction ended and the transaction trace was serialized. Prior to 12.18.2, we added segments to the tree regardless of it they would be collected as part of the trace.  This [PR](https://github.com/newrelic/node-newrelic/pull/3056) changed that behavior, thus exposing this issue in apollo server plugin. 

## How to Test

```sh
npm run versioned
```

## Related Issues
Closes #344
