### PR TITLE
ci: Added `reopened` to `validate-pr` workflow to allow it to run when you close/reopen a release PR

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
       - edited
       - synchronize
 


### PR DESCRIPTION

## Description

When a release PR requires 0 intervention by an engineer, we close/reopen the PR to allow CI to run. this is because CI will not run when it is invoked by another workflow(prepare release).  We were missing the `reopened` type for validate-pr so that worfklow never ran. The way around was to edit the PR title and update it again so it runs.  This PR allows an engineer to close/reopen to get a release PR green