### PR TITLE
chore: Pinned `apollo-server` test version to below 5.0.0

### DIFF
--- a/tests/versioned/apollo-server-express/package.json
+++ b/tests/versioned/apollo-server-express/package.json
@@ -31,7 +31,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@apollo/server": ">=4.0.0",
+        "@apollo/server": ">=4.0.0 <5.0.0",
         "graphql-tag": "latest"
       },
       "files": [

--- a/tests/versioned/apollo-server/package.json
+++ b/tests/versioned/apollo-server/package.json
@@ -16,7 +16,7 @@
       },
       "dependencies": {
         "apollo-server": {
-          "versions": ">=3.0.0",
+          "versions": ">=3.0.0 <5.0.0",
           "samples": 3 
         }
       },
@@ -35,7 +35,7 @@
         "node": ">=18"
       },
       "dependencies": {
-        "@apollo/server": ">=4.0.0",
+        "@apollo/server": ">=4.0.0 <5.0.0",
         "graphql-tag": "latest"
       },
       "files": [


### PR DESCRIPTION
Temporarily pinning tests to below 5.0.0 for apollo-server until we fix tests. 