### PR TITLE
chore: Removed unnecessary code block start

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ const server = new ApolloServer({
 });
 ```
 
-```
-
 ## Usage
 
 The New Relic plugin is known to work with the following Apollo Server modules:


### PR DESCRIPTION
## Description

The current README.md contains an extra code-block start before the Usage section, rendering it as a block of code instead of normal text. This removes it and restores readability.
