### PR TITLE
test: Enabled timers instrumentation since it is now off by default in agent

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -43,26 +43,26 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 
 ### @apollo/server
 
-This product includes source derived from [@apollo/server](https://github.com/apollographql/apollo-server) ([v4.12.2](https://github.com/apollographql/apollo-server/tree/v4.12.2)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v4.12.2/README.md):
+This product includes source derived from [@apollo/server](https://github.com/apollographql/apollo-server) ([v4.13.0](https://github.com/apollographql/apollo-server/tree/v4.13.0)), distributed under the [MIT License](https://github.com/apollographql/apollo-server/blob/v4.13.0/README.md):
 
 ```
 MIT License
 
 Copyright (c) <year> <copyright holders>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
 following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
-EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
@@ -806,7 +806,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### eslint
 
-This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v9.31.0](https://github.com/eslint/eslint/tree/v9.31.0)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v9.31.0/LICENSE):
+This product includes source derived from [eslint](https://github.com/eslint/eslint) ([v9.39.4](https://github.com/eslint/eslint/tree/v9.39.4)), distributed under the [MIT License](https://github.com/eslint/eslint/blob/v9.39.4/LICENSE):
 
 ```
 Copyright OpenJS Foundation and other contributors, <www.openjsf.org>
@@ -1118,7 +1118,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v12.25.0](https://github.com/newrelic/node-newrelic/tree/v12.25.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v12.25.0/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v13.19.2](https://github.com/newrelic/node-newrelic/tree/v13.19.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v13.19.2/LICENSE):
 
 ```
                                  Apache License
@@ -1326,7 +1326,7 @@ This product includes source derived from [newrelic](https://github.com/newrelic
 
 ### semver
 
-This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.7.2](https://github.com/npm/node-semver/tree/v7.7.2)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.7.2/LICENSE):
+This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.7.4](https://github.com/npm/node-semver/tree/v7.7.4)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.7.4/LICENSE):
 
 ```
 The ISC License

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "lockfile-lint": "^4.9.6",
-    "newrelic": "^12.18.2",
+    "newrelic": "^13.5.0",
     "semver": "^7.7.2",
     "sinon": "^11.1.2",
     "tsd": "^0.18.0"

--- a/tests/lib/test-tools.js
+++ b/tests/lib/test-tools.js
@@ -20,6 +20,13 @@ const utils = require('@newrelic/test-utilities')
 const setupErrorSchema = require('./error-setup')
 const { getTypeDefs, resolvers } = require('./data-definitions')
 
+/**
+ * Reusable `afterEach function`
+ *
+ * @param {object} params to function
+ * @param {object} params.t test instance
+ * @param {string} params.testDir path to apollo server
+ */
 async function afterEach({ t, testDir }) {
   const { helper, expressServer, server } = t.nr
 
@@ -35,7 +42,16 @@ async function afterEach({ t, testDir }) {
   unloadModules(testDir)
 }
 
+/**
+ * Utility to setup an apollo server with new relic plugin + agent
+ * @param {object} params to function
+ * @param {object} params.t test instance
+ * @param {string} params.testDir path to apollo server
+ * @param {object} params.agentConfig agent configuration
+ * @param {object} params.pluginConfig plugin configuration
+ */
 async function setupCoreTest({ t, testDir, agentConfig = {}, pluginConfig = {} } = {}) {
+  agentConfig.instrumentation = { timers: { enabled: true } }
   const helper = utils.TestAgent.makeFullyInstrumented(agentConfig)
   const createPlugin = require('../../lib/create-plugin')
   const nrApi = helper.getAgentApi()

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Jul 21 2025 16:04:18 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Mon Apr 20 2026 14:38:39 GMT-0400 (Eastern Daylight Time)",
   "projectName": "New Relic Node Apollo Server Plugin",
   "projectUrl": "https://github.com/newrelic/newrelic-node-apollo-server-plugin/",
   "includeOptDeps": false,
@@ -7,15 +7,15 @@
   "includeDev": true,
   "dependencies": {},
   "devDependencies": {
-    "@apollo/server@4.12.2": {
+    "@apollo/server@4.13.0": {
       "name": "@apollo/server",
-      "version": "4.12.2",
+      "version": "4.13.0",
       "range": "^4.1.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/apollographql/apollo-server",
-      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v4.12.2",
+      "versionedRepoUrl": "https://github.com/apollographql/apollo-server/tree/v4.13.0",
       "licenseFile": "node_modules/@apollo/server/README.md",
-      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v4.12.2/README.md",
+      "licenseUrl": "https://github.com/apollographql/apollo-server/blob/v4.13.0/README.md",
       "licenseTextSource": "spdx",
       "publisher": "Apollo",
       "email": "packages@apollographql.com"
@@ -111,15 +111,15 @@
       "email": "gajus@gajus.com",
       "url": "http://gajus.com"
     },
-    "eslint@9.31.0": {
+    "eslint@9.39.4": {
       "name": "eslint",
-      "version": "9.31.0",
+      "version": "9.39.4",
       "range": "^9.31.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/eslint/eslint",
-      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v9.31.0",
+      "versionedRepoUrl": "https://github.com/eslint/eslint/tree/v9.39.4",
       "licenseFile": "node_modules/eslint/LICENSE",
-      "licenseUrl": "https://github.com/eslint/eslint/blob/v9.31.0/LICENSE",
+      "licenseUrl": "https://github.com/eslint/eslint/blob/v9.39.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Nicholas C. Zakas",
       "email": "nicholas+npm@nczconsulting.com"
@@ -175,28 +175,28 @@
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@12.25.0": {
+    "newrelic@13.19.2": {
       "name": "newrelic",
-      "version": "12.25.0",
-      "range": "^12.18.2",
+      "version": "13.19.2",
+      "range": "^13.9.2",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v12.25.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v13.19.2",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v12.25.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v13.19.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"
     },
-    "semver@7.7.2": {
+    "semver@7.7.4": {
       "name": "semver",
-      "version": "7.7.2",
+      "version": "7.7.4",
       "range": "^7.7.2",
       "licenses": "ISC",
       "repoUrl": "https://github.com/npm/node-semver",
-      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.7.2",
+      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.7.4",
       "licenseFile": "node_modules/semver/LICENSE",
-      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.7.2/LICENSE",
+      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.7.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "GitHub Inc."
     },


### PR DESCRIPTION
## Description

Since 13.5.0 of the agent, we have disabled timers instrumentation.  This plugin relies on it for its tests.  We had a previous [branch](https://github.com/newrelic/newrelic-node-apollo-server-plugin/tree/remove-set-timeout) that was never merged that removed `setTimeout` calls in the test apollo server. However, they are important to indicate that resolver/mutation segments have proper children.  This PR updates the test agent to enable timers intrumentation. It also updates the dev dep of `newrelic` to be `13.5.0`+
